### PR TITLE
default quests, claim map, and party chat in top left of rei

### DIFF
--- a/config/heracles/quests/gettingstarted/arms_are_full.json
+++ b/config/heracles/quests/gettingstarted/arms_are_full.json
@@ -4,16 +4,18 @@
   ],
   "tasks": {
     "arms_are_full_task": {
+      "type": "heracles:item",
+      "item": "travelersbackpack:standard",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
       "icon": {
         "item": {
           "id": "minecraft:air",
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "item": "travelersbackpack:standard",
-      "title": "",
-      "type": "heracles:item_interaction"
+      }
     }
   },
   "rewards": {

--- a/config/heracles/quests/gettingstarted/portable_mass.json
+++ b/config/heracles/quests/gettingstarted/portable_mass.json
@@ -41,7 +41,7 @@
       "Getting Started": {
         "position": [
           -50,
-          99
+          100
         ]
       }
     },

--- a/config/roughlyenoughitems/config.json5
+++ b/config/roughlyenoughitems/config.json5
@@ -1,6 +1,10 @@
 {
 	"basics": {
-		"favorites": [],
+		"favorites": [
+			"{type:\"heracles:heracles\"}",
+			"{type:\"cadmus:cadmus\"}",
+			"{type:\"argonauts:party_chat\"}"
+		],
 		"hiddenFavorites": [],
 		"displayHistory": [],
 		// Declares whether cheating mode is on.


### PR DESCRIPTION
default quests, claim map, and party chat in top left of rei

fixed task type of "arms_are_full"

y-axis coordinate of "portable_mass" was inconsitent