### PR TITLE
Botania Orechid modded ore compat

### DIFF
--- a/kubejs/data/botania/recipes/orechid/antimony_ore.json
+++ b/kubejs/data/botania/recipes/orechid/antimony_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:antimony_ore"
+  },
+  "weight": 17500
+}

--- a/kubejs/data/botania/recipes/orechid/bauxite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/bauxite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:bauxite_ore"
+  },
+  "weight": 18000
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_antimony_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_antimony_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_antimony_ore"
+  },
+  "weight": 115
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_bauxite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_bauxite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_bauxite_ore"
+  },
+  "weight": 300
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_galena_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_galena_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "techreborn:deepslate_galena_ore"
+  },
+  "weight": 133
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_lead_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_lead_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_lead_ore"
+  },
+  "weight": 290
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_lignite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_lignite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_lignite_coal_ore"
+  },
+  "weight": 160
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_monazite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_monazite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_monazite_ore"
+  },
+  "weight": 85
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_nickel_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_nickel_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_nickel_ore"
+  },
+  "weight": 215
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_nikolite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_nikolite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "indrev:deepslate_nikolite_ore"
+  },
+  "weight": 110
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_salt_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_salt_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_salt_ore"
+  },
+  "weight": 229
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_silver_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_silver_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "techreborn:deepslate_silver_ore"
+  },
+  "weight": 130
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_tin_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_tin_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_tin_ore"
+  },
+  "weight": 125
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_tungsten_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_tungsten_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_tungsten_ore"
+  },
+  "weight": 133
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_uraninite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_uraninite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "powah:deepslate_uraninite_ore"
+  },
+  "weight": 146
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_uranium_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_uranium_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:deepslate_uranium_ore"
+  },
+  "weight": 144
+}

--- a/kubejs/data/botania/recipes/orechid/deepslate_zinc_ore.json
+++ b/kubejs/data/botania/recipes/orechid/deepslate_zinc_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:deepslate"
+  },
+  "output": {
+    "type": "block",
+    "block": "create:deepslate_zinc_ore"
+  },
+  "weight": 140
+}

--- a/kubejs/data/botania/recipes/orechid/galena_ore.json
+++ b/kubejs/data/botania/recipes/orechid/galena_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "techreborn:galena_ore"
+  },
+  "weight": 13330
+}

--- a/kubejs/data/botania/recipes/orechid/lead_ore.json
+++ b/kubejs/data/botania/recipes/orechid/lead_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:lead_ore"
+  },
+  "weight": 17500
+}

--- a/kubejs/data/botania/recipes/orechid/lignite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/lignite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:lignite_coal_ore"
+  },
+  "weight": 68000
+}

--- a/kubejs/data/botania/recipes/orechid/monazite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/monazite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:monazite_ore"
+  },
+  "weight": 730
+}

--- a/kubejs/data/botania/recipes/orechid/nickel_ore.json
+++ b/kubejs/data/botania/recipes/orechid/nickel_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:nickel_ore"
+  },
+  "weight": 20500
+}

--- a/kubejs/data/botania/recipes/orechid/nikolite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/nikolite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "indrev:nikolite_ore"
+  },
+  "weight": 2900
+}

--- a/kubejs/data/botania/recipes/orechid/salt_ore.json
+++ b/kubejs/data/botania/recipes/orechid/salt_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:salt_ore"
+  },
+  "weight": 22300
+}

--- a/kubejs/data/botania/recipes/orechid/silver_ore.json
+++ b/kubejs/data/botania/recipes/orechid/silver_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "techreborn:silver_ore"
+  },
+  "weight": 4440
+}

--- a/kubejs/data/botania/recipes/orechid/tin_ore.json
+++ b/kubejs/data/botania/recipes/orechid/tin_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:tin_ore"
+  },
+  "weight": 16600
+}

--- a/kubejs/data/botania/recipes/orechid/tungsten_ore.json
+++ b/kubejs/data/botania/recipes/orechid/tungsten_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:tungsten_ore"
+  },
+  "weight": 1430
+}

--- a/kubejs/data/botania/recipes/orechid/uraninite_ore.json
+++ b/kubejs/data/botania/recipes/orechid/uraninite_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "powah:uraninite_ore"
+  },
+  "weight": 14300
+}

--- a/kubejs/data/botania/recipes/orechid/uranium_ore.json
+++ b/kubejs/data/botania/recipes/orechid/uranium_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "modern_industrialization:uranium_ore"
+  },
+  "weight": 14552
+}

--- a/kubejs/data/botania/recipes/orechid/zinc_ore.json
+++ b/kubejs/data/botania/recipes/orechid/zinc_ore.json
@@ -1,0 +1,12 @@
+{
+  "type": "botania:orechid",
+  "input": {
+    "type": "block",
+    "block": "minecraft:stone"
+  },
+  "output": {
+    "type": "block",
+    "block": "create:zinc_ore"
+  },
+  "weight": 3870
+}


### PR DESCRIPTION
This adds support for several modded ores to the Botania Orechid flower. I picked ores based on whether or not they were found in worldgen, and excludes certain ores I thought were "special" and still deserve to be sought out yourself.