### PR TITLE
Add missing translations for endgame MI quest titles

### DIFF
--- a/config/heracles/quests/modernindustrialization/fusion_reactor.json
+++ b/config/heracles/quests/modernindustrialization/fusion_reactor.json
@@ -93,7 +93,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "fusion_reactor"
+      "translate": "Fusion Reactor"
     }
   },
   "settings": {

--- a/config/heracles/quests/modernindustrialization/nuke.json
+++ b/config/heracles/quests/modernindustrialization/nuke.json
@@ -63,7 +63,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "nuke"
+      "translate": "Legalized Nuclear Bomb"
     }
   },
   "settings": {

--- a/config/heracles/quests/modernindustrialization/plasma_turbine.json
+++ b/config/heracles/quests/modernindustrialization/plasma_turbine.json
@@ -93,7 +93,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "plasma_turbine"
+      "translate": "Plasma Turbine"
     }
   },
   "settings": {

--- a/config/heracles/quests/modernindustrialization/quantum_upgrade.json
+++ b/config/heracles/quests/modernindustrialization/quantum_upgrade.json
@@ -65,7 +65,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "quantum_upgrade"
+      "translate": "Quantum Upgrade"
     }
   },
   "settings": {

--- a/config/heracles/quests/modernindustrialization/singularity.json
+++ b/config/heracles/quests/modernindustrialization/singularity.json
@@ -63,7 +63,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "singularity"
+      "translate": "Singularity"
     }
   },
   "settings": {

--- a/config/heracles/quests/modernindustrialization/the_endgame.json
+++ b/config/heracles/quests/modernindustrialization/the_endgame.json
@@ -63,7 +63,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "the_endgame"
+      "translate": "The Endgame"
     }
   },
   "settings": {


### PR DESCRIPTION
Several quests at the end of the MI chapter had placeholder titles, this commit replaces them with more fitting ones.