### PR TITLE
fix AE2 Spatial dimension black screen with IF

### DIFF
--- a/config/immediatelyfast.json
+++ b/config/immediatelyfast.json
@@ -4,7 +4,7 @@
   "map_atlas_generation": true,
   "hud_batching": true,
   "fast_text_lookup": true,
-  "fast_buffer_upload": true,
+  "fast_buffer_upload": false,
   "fast_buffer_upload_size_mb": 256,
   "fast_buffer_upload_explicit_flush": true,
   "COSMETIC_INFO": "----- Cosmetic only config values below (Does not optimize anything) -----",


### PR DESCRIPTION
Immediately Fast and AE2 clash on some graphics cards. Entering the Spatial dimension causes the entire game to go black and causes OpenGL issues until the game is reloaded. Disabling Fast Buffer Upload can remediate this