### PR TITLE
Quests complete (most likely)

### DIFF
--- a/config/heracles/quests/farmeroworlds/A Bottle of 'Creepers Crush'.json
+++ b/config/heracles/quests/farmeroworlds/A Bottle of 'Creepers Crush'.json
@@ -54,6 +54,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/A Bottle of 'Mojang Noir'.json
+++ b/config/heracles/quests/farmeroworlds/A Bottle of 'Mojang Noir'.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/A Bottle of 'Villagers Fright'.json
+++ b/config/heracles/quests/farmeroworlds/A Bottle of 'Villagers Fright'.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/A Refreshing Drink.json
+++ b/config/heracles/quests/farmeroworlds/A Refreshing Drink.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Tiki Bar"
   ],
   "tasks": {
-    "fr": {
+    "bprd": {
+      "type": "heracles:item",
+      "item": "beachparty:refreshing_drink",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "A simple refreshing drink and a great way to make sweetberries more useful"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          70,
+          -260
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "beachparty:refreshing_drink",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "A Refreshing Drink"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/A Refreshing Drink.json
+++ b/config/heracles/quests/farmeroworlds/A Refreshing Drink.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Aegis Wine.json
+++ b/config/heracles/quests/farmeroworlds/Aegis Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Aging Barrel.json
+++ b/config/heracles/quests/farmeroworlds/Aging Barrel.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Animal Husbandry.json
+++ b/config/heracles/quests/farmeroworlds/Animal Husbandry.json
@@ -1,11 +1,25 @@
 {
   "dependencies": [
-    "Wine ageing"
+    "Farming for Blockheads"
   ],
   "tasks": {
-    "vcw": {
+    "ffbft": {
       "type": "heracles:item",
-      "item": "vinery:cherry_wine",
+      "item": "farmingforblockheads:feeding_trough",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ffben": {
+      "type": "heracles:item",
+      "item": "farmingforblockheads:chicken_nest",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -24,26 +38,28 @@
       "text": ""
     },
     "description": [
-      "Gives regeneration"
+      "Chicken nests are an easy way to collect eggs",
+      "<br/>",
+      "Feeding troughs are an easy way to breed animals"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          210,
-          -245
+          -35,
+          -160
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "vinery:cherry_wine",
+        "id": "farmingforblockheads:chicken_nest",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Cherry Wine"
+      "translate": "Animal Husbandry"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Apple Pie.json
+++ b/config/heracles/quests/farmeroworlds/Apple Pie.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Apple Press.json
+++ b/config/heracles/quests/farmeroworlds/Apple Press.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Apple Trees.json
+++ b/config/heracles/quests/farmeroworlds/Apple Trees.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Apple Wine.json
+++ b/config/heracles/quests/farmeroworlds/Apple Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Ascending Berries.json
+++ b/config/heracles/quests/farmeroworlds/Ascending Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Ascending Berries.json
+++ b/config/heracles/quests/farmeroworlds/Ascending Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbab": {
+      "type": "heracles:item",
+      "item": "strangeberries:ascending_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found on windswept hills, windswept gravely hills, windswept forest and windswept savanna",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make slow falling potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -181,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:ascending_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Ascending Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Asian Cuisine.json
+++ b/config/heracles/quests/farmeroworlds/Asian Cuisine.json
@@ -149,6 +149,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Baguette.json
+++ b/config/heracles/quests/farmeroworlds/Baguette.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Baked Fish Stew.json
+++ b/config/heracles/quests/farmeroworlds/Baked Fish Stew.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "The Fish"
   ],
   "tasks": {
-    "fdsip": {
+    "ndbbs": {
       "type": "heracles:item",
-      "item": "farmersdelight:squid_ink_pasta",
+      "item": "netherdepthsupgrade:baked_blazefish_stew",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdts": {
+    "ndbss": {
       "type": "heracles:item",
-      "item": "farmersdelight:tomato_sauce",
+      "item": "netherdepthsupgrade:baked_soulsucker_stew",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdrp": {
+    "ndbscs": {
       "type": "heracles:item",
-      "item": "farmersdelight:raw_pasta",
+      "item": "netherdepthsupgrade:baked_searing_cod_stew",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdwd": {
+    "ndbmcfs": {
       "type": "heracles:item",
-      "item": "farmersdelight:wheat_dough",
+      "item": "netherdepthsupgrade:baked_magmacubefish_stew",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "fdpwm": {
+    "ndbgs": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_meatballs",
+      "item": "netherdepthsupgrade:baked_glowdine_stew",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -73,9 +73,9 @@
         "type": "heracles:item"
       }
     },
-    "fdvn": {
+    "ndblps": {
       "type": "heracles:item",
-      "item": "farmersdelight:vegetable_noodles",
+      "item": "netherdepthsupgrade:baked_lava_pufferfish_stew",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -87,23 +87,9 @@
         "type": "heracles:item"
       }
     },
-    "fdns": {
+    "ndbos": {
       "type": "heracles:item",
-      "item": "farmersdelight:noodle_soup",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdpwmc": {
-      "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_mutton_chop",
+      "item": "netherdepthsupgrade:baked_obsidianfish_stew",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -122,32 +108,26 @@
       "text": ""
     },
     "description": [
-      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
-      "<br/>",
-      "<br/>",
-      "Wheat dough can also be made in multiple ways",
-      "<br/>",
-      "<br/>",
-      "You will also want to make some tomato sauce for the more traditional pasta"
+      "Baked fish stews are another highly nourishing way of preparing your fish, in this case they can only be made with a Create heated mixer"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          50
+          -500,
+          110
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:raw_pasta",
+        "id": "netherdepthsupgrade:baked_searing_cod_stew",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Pasta"
+      "translate": "Baked Fish Stew"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Baked Fish Stew.json
+++ b/config/heracles/quests/farmeroworlds/Baked Fish Stew.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Bakery.json
+++ b/config/heracles/quests/farmeroworlds/Bakery.json
@@ -41,7 +41,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Bakery"
     }

--- a/config/heracles/quests/farmeroworlds/Bakery.json
+++ b/config/heracles/quests/farmeroworlds/Bakery.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Baking Basics.json
+++ b/config/heracles/quests/farmeroworlds/Baking Basics.json
@@ -67,7 +67,7 @@
       "Farmer O' Worlds": {
         "position": [
           -75,
-          -130
+          -140
         ]
       }
     },
@@ -88,6 +88,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Baking Utilities.json
+++ b/config/heracles/quests/farmeroworlds/Baking Utilities.json
@@ -104,7 +104,7 @@
       "Farmer O' Worlds": {
         "position": [
           -105,
-          -130
+          -140
         ]
       }
     },
@@ -125,6 +125,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Beachparty.json
+++ b/config/heracles/quests/farmeroworlds/Beachparty.json
@@ -41,7 +41,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Beachparty"
     }

--- a/config/heracles/quests/farmeroworlds/Beachparty.json
+++ b/config/heracles/quests/farmeroworlds/Beachparty.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Berries Assemble.json
+++ b/config/heracles/quests/farmeroworlds/Berries Assemble.json
@@ -1,9 +1,9 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "An Introduction"
   ],
   "tasks": {
-    "fr": {
+    "sb": {
       "title": "",
       "icon": {
         "item": {
@@ -21,29 +21,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Strange berries give a short effect and all have a different spawn locations, they can also be used to make potions",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "But be careful with eating too many different berries or you will get berry sickness, berry sickness will quickly drain your saturation and hunger and prevent you from regaining food"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -265,
+          143
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "minecraft:sweet_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Berries Assemble"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Berries Assemble.json
+++ b/config/heracles/quests/farmeroworlds/Berries Assemble.json
@@ -40,7 +40,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Berries Assemble"
     }
@@ -50,6 +50,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Berries.json
+++ b/config/heracles/quests/farmeroworlds/Berries.json
@@ -1,0 +1,76 @@
+{
+  "dependencies": [
+    "Fright's Delight"
+  ],
+  "tasks": {
+    "frdwb": {
+      "type": "heracles:item",
+      "item": "frightsdelight:wither_berry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsb": {
+      "type": "heracles:item",
+      "item": "frightsdelight:soul_berry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "There are 2 new types of berries:",
+      "<br/>",
+      "<br/>",
+      "First soul berries, they are found in bastion chests in the Nether, to grow them plant them on soul sand or soul soil, they require a soul torch or soul fire near them to grow",
+      "<br/>",
+      "<br/>",
+      "Second wither berries, they have to be made, to make them you will need a fully grown soul berry bush, place a wither rose or wither skull next to it and block all light off, after a bit of time it will turn into a wither berry bush, the wither block and darkness will still be needed to keep growing"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -420,
+          75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "frightsdelight:soul_berry",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Berries"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Berries.json
+++ b/config/heracles/quests/farmeroworlds/Berries.json
@@ -71,6 +71,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Big Meals.json
+++ b/config/heracles/quests/farmeroworlds/Big Meals.json
@@ -1,9 +1,9 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Meats and Dragon Drops"
   ],
   "tasks": {
-    "ed": {
+    "edbm": {
       "title": "",
       "icon": {
         "item": {
@@ -21,35 +21,26 @@
       "text": ""
     },
     "description": [
-      "Ever found yourself starving in the End with nothing else to eat than annoying chorus fruit? Well now you will have a whole new --dimension-- of thing to eat, with multiple recipes both simple and powerful",
-      "<br/>",
-      "<br/>",
-      "You will also now have a new stove and a few new knives",
-      "<br/>",
-      "<br/>",
-      "You can also use Create to cook these foods"
+      "These foods must be placed down and must be picked up with a bowl to be eaten, they restore a lot of hunger and give many positive effects"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -540,
-          -40
+          -575,
+          -105
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "ends_delight:dragon_tooth_knife",
-        "count": 1,
-        "nbt": {
-          "Damage": 0
-        }
+        "id": "ends_delight:dragon_leg_with_sauce",
+        "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "End's Delight"
+      "translate": "Big Meals"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Big Meals.json
+++ b/config/heracles/quests/farmeroworlds/Big Meals.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Big Wine Bottle Storage.json
+++ b/config/heracles/quests/farmeroworlds/Big Wine Bottle Storage.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Blank Cake.json
+++ b/config/heracles/quests/farmeroworlds/Blank Cake.json
@@ -30,7 +30,7 @@
       "Farmer O' Worlds": {
         "position": [
           -75,
-          -160
+          -170
         ]
       }
     },
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Blazewine Pinot.json
+++ b/config/heracles/quests/farmeroworlds/Blazewine Pinot.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Bolvar Wine.json
+++ b/config/heracles/quests/farmeroworlds/Bolvar Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Braided Bread.json
+++ b/config/heracles/quests/farmeroworlds/Braided Bread.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Bread Basket.json
+++ b/config/heracles/quests/farmeroworlds/Bread Basket.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Bread.json
+++ b/config/heracles/quests/farmeroworlds/Bread.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Breads.json
+++ b/config/heracles/quests/farmeroworlds/Breads.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Brewin' and Chewin'.json
+++ b/config/heracles/quests/farmeroworlds/Brewin' and Chewin'.json
@@ -41,7 +41,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Brewin' and Chewin'"
     }

--- a/config/heracles/quests/farmeroworlds/Brewin' and Chewin'.json
+++ b/config/heracles/quests/farmeroworlds/Brewin' and Chewin'.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Brewin' and Chewin'.json
+++ b/config/heracles/quests/farmeroworlds/Brewin' and Chewin'.json
@@ -3,7 +3,7 @@
     "Farmer's Delight"
   ],
   "tasks": {
-    "fr": {
+    "bc": {
       "title": "",
       "icon": {
         "item": {
@@ -21,29 +21,29 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Brewin' and Chewin' is all about fermenting drinks and food in a keg through a new unique fermentation system",
       "<br/>",
       "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "You will be able to make new foods and drinks with some positive effects, but careful not to drink too much!"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
           -640,
-          15
+          -15
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "brewinandchewin:tankard",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Brewin' and Chewin'"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Bun.json
+++ b/config/heracles/quests/farmeroworlds/Bun.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Bundt Cake.json
+++ b/config/heracles/quests/farmeroworlds/Bundt Cake.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cake and Pie.json
+++ b/config/heracles/quests/farmeroworlds/Cake and Pie.json
@@ -93,6 +93,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cake and Pie.json
+++ b/config/heracles/quests/farmeroworlds/Cake and Pie.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Kettle"
   ],
   "tasks": {
-    "fdcr": {
+    "frcc": {
       "type": "heracles:item",
-      "item": "farmersdelight:cooked_rice",
+      "item": "farmersrespite:coffee_cake",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdsr": {
+    "frrhp": {
       "type": "heracles:item",
-      "item": "farmersdelight:salmon_roll",
+      "item": "farmersrespite:rose_hip_pie",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdkrs": {
+    "frccs": {
       "type": "heracles:item",
-      "item": "farmersdelight:kelp_roll_slice",
+      "item": "farmersrespite:coffee_cake_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,51 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdfr": {
+    "frrhps": {
       "type": "heracles:item",
-      "item": "farmersdelight:fried_rice",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdkr": {
-      "type": "heracles:item",
-      "item": "farmersdelight:kelp_roll",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdmr": {
-      "type": "heracles:item",
-      "item": "farmersdelight:mushroom_rice",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdcr0": {
-      "type": "heracles:item",
-      "item": "farmersdelight:cod_roll",
+      "item": "farmersrespite:rose_hip_pie_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -108,26 +66,26 @@
       "text": ""
     },
     "description": [
-      "Sushi and rice offer a great variety of possibilities in the cooking world and sushi wouldn't be what it is without rice!"
+      "These two foods can be placed down and eaten from there or be cut into slices on a cutting board"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          100
+          -630,
+          -35
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:kelp_roll",
+        "id": "farmersrespite:coffee_cake",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Sushi and Rice Dishes"
+      "translate": "Cake and Pie"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Cake and Pie.json
+++ b/config/heracles/quests/farmeroworlds/Cake and Pie.json
@@ -71,8 +71,8 @@
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -630,
-          -35
+          -720,
+          50
         ]
       }
     },

--- a/config/heracles/quests/farmeroworlds/Cakes, Pies and Tarts.json
+++ b/config/heracles/quests/farmeroworlds/Cakes, Pies and Tarts.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cheese Making.json
+++ b/config/heracles/quests/farmeroworlds/Cheese Making.json
@@ -96,6 +96,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cheese Making.json
+++ b/config/heracles/quests/farmeroworlds/Cheese Making.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Kettle"
+    "The Keg"
   ],
   "tasks": {
-    "frgtc": {
+    "bcfcw": {
       "type": "heracles:item",
-      "item": "farmersrespite:green_tea_cookie",
+      "item": "brewinandchewin:flaxen_cheese_wheel",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc0": {
+    "bcscw": {
       "type": "heracles:item",
-      "item": "farmersrespite:black_cod",
+      "item": "brewinandchewin:scarlet_cheese_wheel",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "frtc": {
+    "bcscws": {
       "type": "heracles:item",
-      "item": "farmersrespite:tea_curry",
+      "item": "brewinandchewin:scarlet_cheese_wedge",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,23 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "frnws": {
+    "bcfcws": {
       "type": "heracles:item",
-      "item": "farmersrespite:nether_wart_sourdough",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "frbc": {
-      "type": "heracles:item",
-      "item": "farmersrespite:blazing_chili",
+      "item": "brewinandchewin:flaxen_cheese_wedge",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -80,26 +66,29 @@
       "text": ""
     },
     "description": [
-      "These are some foods made with ingredients used to make the teas and coffee"
+      "With your new keg you will be able to do more than just drinks, now you can also make 2 new types of cheese, to make them you will need a warm keg, after the cheese is done it must be placed down for it to age, you will know when it's done ageing because it will change it's color, after that it can be cut with a knife or picked up for storage or cutting in a board",
+      "<br/>",
+      "<br/>",
+      "With your cheese now aged and cut you will now be able to start cooking"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -650,
-          50
+          -730,
+          -15
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:blazing_chili",
+        "id": "brewinandchewin:flaxen_cheese_wedge",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Other Foods"
+      "translate": "Cheese Making"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Chenet Wine.json
+++ b/config/heracles/quests/farmeroworlds/Chenet Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cherry Trees.json
+++ b/config/heracles/quests/farmeroworlds/Cherry Trees.json
@@ -57,6 +57,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Chocolate Cake.json
+++ b/config/heracles/quests/farmeroworlds/Chocolate Cake.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Chocolate Tart.json
+++ b/config/heracles/quests/farmeroworlds/Chocolate Tart.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Chocolate Truffle.json
+++ b/config/heracles/quests/farmeroworlds/Chocolate Truffle.json
@@ -79,6 +79,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Chorus Wine.json
+++ b/config/heracles/quests/farmeroworlds/Chorus Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cider.json
+++ b/config/heracles/quests/farmeroworlds/Cider.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cinammon.json
+++ b/config/heracles/quests/farmeroworlds/Cinammon.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Clark Wine.json
+++ b/config/heracles/quests/farmeroworlds/Clark Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cocoa Cocktail.json
+++ b/config/heracles/quests/farmeroworlds/Cocoa Cocktail.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Coconut Cocktail.json
+++ b/config/heracles/quests/farmeroworlds/Coconut Cocktail.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Coconuts.json
+++ b/config/heracles/quests/farmeroworlds/Coconuts.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cold Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Cold Drinks.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cold Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Cold Drinks.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "The Keg"
   ],
   "tasks": {
-    "fr": {
+    "bcsf": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:salty_folly",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "bcgg": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:glittering_grenadine",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +38,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "A collection of drinks made with a cold keg"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -710,
+          -90
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "brewinandchewin:salty_folly",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Cold Drinks"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Cooked Cuts.json
+++ b/config/heracles/quests/farmeroworlds/Cooked Cuts.json
@@ -3,48 +3,6 @@
     "Ingredient Duplication"
   ],
   "tasks": {
-    "fdccc": {
-      "type": "heracles:item",
-      "item": "farmersdelight:cooked_chicken_cuts",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdccs": {
-      "type": "heracles:item",
-      "item": "farmersdelight:cooked_cod_slice",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdcss": {
-      "type": "heracles:item",
-      "item": "farmersdelight:cooked_salmon_slice",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "fdcb": {
       "type": "heracles:item",
       "item": "farmersdelight:cooked_bacon",
@@ -76,6 +34,48 @@
     "fdcmc": {
       "type": "heracles:item",
       "item": "farmersdelight:cooked_mutton_chops",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdccc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_chicken_cuts",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdccs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_cod_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcss": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_salmon_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -121,6 +121,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cooked Cuts.json
+++ b/config/heracles/quests/farmeroworlds/Cooked Cuts.json
@@ -1,0 +1,126 @@
+{
+  "dependencies": [
+    "Ingredient Duplication"
+  ],
+  "tasks": {
+    "fdccc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_chicken_cuts",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdccs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_cod_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcss": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_salmon_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcb": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_bacon",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdbp": {
+      "type": "heracles:item",
+      "item": "farmersdelight:beef_patty",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcmc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_mutton_chops",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "All meat and fish cuts can be cooked either for other recipes or to just have a better snack"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -325,
+          -100
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:beef_patty",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Cooked Cuts"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Cooked Fish Slices.json
+++ b/config/heracles/quests/farmeroworlds/Cooked Fish Slices.json
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cooked Fish Slices.json
+++ b/config/heracles/quests/farmeroworlds/Cooked Fish Slices.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Fish Slices"
   ],
   "tasks": {
-    "fdsip": {
+    "ndcss": {
       "type": "heracles:item",
-      "item": "farmersdelight:squid_ink_pasta",
+      "item": "netherdepthsupgrade:cooked_soulsucker_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdts": {
+    "ndcmcfs": {
       "type": "heracles:item",
-      "item": "farmersdelight:tomato_sauce",
+      "item": "netherdepthsupgrade:cooked_magmacubefish_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdrp": {
+    "ndcgs": {
       "type": "heracles:item",
-      "item": "farmersdelight:raw_pasta",
+      "item": "netherdepthsupgrade:cooked_glowdine_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdwd": {
+    "ndcos": {
       "type": "heracles:item",
-      "item": "farmersdelight:wheat_dough",
+      "item": "netherdepthsupgrade:cooked_obsidianfish_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,51 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "fdpwm": {
+    "ndclps": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_meatballs",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdvn": {
-      "type": "heracles:item",
-      "item": "farmersdelight:vegetable_noodles",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdns": {
-      "type": "heracles:item",
-      "item": "farmersdelight:noodle_soup",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdpwmc": {
-      "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_mutton_chop",
+      "item": "netherdepthsupgrade:cooked_lava_pufferfish_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -122,32 +80,26 @@
       "text": ""
     },
     "description": [
-      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
-      "<br/>",
-      "<br/>",
-      "Wheat dough can also be made in multiple ways",
-      "<br/>",
-      "<br/>",
-      "You will also want to make some tomato sauce for the more traditional pasta"
+      "A more filling alternative to regular fish slices if you don't want to make more complex dishes"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          50
+          -615,
+          125
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:raw_pasta",
+        "id": "netherdepthsupgrade:cooked_glowdine_slice",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Pasta"
+      "translate": "Cooked Fish Slices"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Cooked Foods.json
+++ b/config/heracles/quests/farmeroworlds/Cooked Foods.json
@@ -205,6 +205,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cooked Meats.json
+++ b/config/heracles/quests/farmeroworlds/Cooked Meats.json
@@ -3,20 +3,6 @@
     "Meats and Dragon Drops"
   ],
   "tasks": {
-    "edrdmc": {
-      "type": "heracles:item",
-      "item": "ends_delight:roasted_dragon_meat_cuts",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "edsdl": {
       "type": "heracles:item",
       "item": "ends_delight:smoked_dragon_leg",
@@ -86,6 +72,20 @@
         },
         "type": "heracles:item"
       }
+    },
+    "edrdmc": {
+      "type": "heracles:item",
+      "item": "ends_delight:roasted_dragon_meat_cuts",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -124,6 +124,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cooked Meats.json
+++ b/config/heracles/quests/farmeroworlds/Cooked Meats.json
@@ -1,0 +1,129 @@
+{
+  "dependencies": [
+    "Meats and Dragon Drops"
+  ],
+  "tasks": {
+    "edrdmc": {
+      "type": "heracles:item",
+      "item": "ends_delight:roasted_dragon_meat_cuts",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edsdl": {
+      "type": "heracles:item",
+      "item": "ends_delight:smoked_dragon_leg",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edrdm": {
+      "type": "heracles:item",
+      "item": "ends_delight:roasted_dragon_meat",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edrsm": {
+      "type": "heracles:item",
+      "item": "ends_delight:roasted_shulker_meat",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "eddem": {
+      "type": "heracles:item",
+      "item": "ends_delight:dried_endermite_meat",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edrsms": {
+      "type": "heracles:item",
+      "item": "ends_delight:roasted_shulker_meat_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "All the meats can be cooked for some extra nourishment or to be used in different recipes",
+      "<br/>",
+      "<br/>",
+      "The smoked dragon leg and dried endermite meat can only be cooked in the smoker"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -505,
+          -75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:roasted_dragon_meat",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Cooked Meats"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Cooking Books.json
+++ b/config/heracles/quests/farmeroworlds/Cooking Books.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Cooking for Blockheads"
   ],
   "tasks": {
-    "bsgc0": {
+    "cfbcfb2": {
       "type": "heracles:item",
-      "item": "bakery:sweetberry_glazed_cookie",
+      "item": "cookingforblockheads:crafting_book",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bsgc": {
+    "cfbcfb1": {
       "type": "heracles:item",
-      "item": "bakery:strawberry_glazed_cookie",
+      "item": "cookingforblockheads:recipe_book",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "bcgc": {
+    "cfbcfb": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_glazed_cookie",
+      "item": "cookingforblockheads:no_filter_edition",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +52,35 @@
       "text": ""
     },
     "description": [
-      "A collection of cookies, these can't be placed"
+      "Cooking for Blockheads I allows to see what foods can be made with what ingredients you have",
+      "<br/>",
+      "<br/>",
+      "Cooking for blockheads II allows to see and craft what foods can be made with what ingredients you have",
+      "<br/>",
+      "<br/>",
+      "Cooking for blockheads allows to see all recipes and to craft those that you have ingredients for, it is the ultimate cooking book",
+      "<br/>",
+      "<br/>",
+      "The best use for these books is to place them on the cooking table, this will allow to see what can be made with every block of your kitchen and even cook those foods"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -193,
-          -240
+          -90,
+          -65
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:strawberry_glazed_cookie",
+        "id": "cookingforblockheads:no_filter_edition",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Cookies"
+      "translate": "Cooking Books"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Cooking Tools.json
+++ b/config/heracles/quests/farmeroworlds/Cooking Tools.json
@@ -130,6 +130,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cooking Tools.json
+++ b/config/heracles/quests/farmeroworlds/Cooking Tools.json
@@ -1,0 +1,135 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdcb": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cutting_board",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcp": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooking_pot",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fds": {
+      "type": "heracles:item",
+      "item": "farmersdelight:stove",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdk": {
+      "type": "heracles:item",
+      "item": "#c:tools/knives",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdskillet": {
+      "type": "heracles:item",
+      "item": "farmersdelight:skillet",
+      "nbt": {
+        "Damage": 0
+      },
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "There are 3 main things for cooking",
+      "<br/>",
+      "<br/>",
+      "First and most important, the cooking pot, here you will cook most foods, it requires a source of heat which can be a campfire, lava, fire or preferably a stove",
+      "<br/>",
+      "<br/>",
+      "The stove is safe and good looking source of heat for your stove and skillet",
+      "<br/>",
+      "<br/>",
+      "The skillet can be used as a weapon or for cooking, simply shift right click where you wish to place it, it will also require a source of heat and it allows to leave a stack of food in it that will slowly get cooked and then be dropped to the ground just like a campfire",
+      "<br/>",
+      "<br/>",
+      "The cutting board has many recipes and not just for food, it allows using a knife to cut something into something else, to double meats and fish or to obtain slices from the many cakes and pies.",
+      "The cutting board also has other recipes that use different tools, like stripping bark of a log with an axe, make sure to check REI for all possibilities",
+      "<br/>",
+      "<br/>",
+      "Knives can be used to cut things in the cutting board, they can also be used as a weapon although they aren't very strong, however, to obtain ham you will need to kill pigs or hoglins with a knife",
+      "Knives can also be made of many materials"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -325,
+          -40
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:skillet",
+        "count": 1,
+        "nbt": {
+          "Damage": 0
+        }
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Cooking Tools"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Cooking for Blockheads.json
+++ b/config/heracles/quests/farmeroworlds/Cooking for Blockheads.json
@@ -1,13 +1,9 @@
 {
   "dependencies": [
-    "Wine ageing"
+    "An Introduction"
   ],
   "tasks": {
-    "vcw": {
-      "type": "heracles:item",
-      "item": "vinery:cherry_wine",
-      "amount": 1,
-      "collection": "AUTOMATIC",
+    "cfb": {
       "title": "",
       "icon": {
         "item": {
@@ -15,7 +11,8 @@
           "count": 0
         },
         "type": "heracles:item"
-      }
+      },
+      "type": "heracles:check"
     }
   },
   "rewards": {},
@@ -24,26 +21,26 @@
       "text": ""
     },
     "description": [
-      "Gives regeneration"
+      "The journey of a professional chef isn't an easy one, these things will aid you in your cooking journey"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          210,
-          -245
+          -35,
+          -80
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "vinery:cherry_wine",
+        "id": "cookingforblockheads:recipe_book",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
-      "translate": "Cherry Wine"
+      "translate": "Cooking for Blockheads"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Crimson Fire Berries.json
+++ b/config/heracles/quests/farmeroworlds/Crimson Fire Berries.json
@@ -55,6 +55,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Crimson Fire Berries.json
+++ b/config/heracles/quests/farmeroworlds/Crimson Fire Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbcfb": {
+      "type": "heracles:item",
+      "item": "strangeberries:crimson_fire_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,30 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found on crimson forests and on netherrack",
       "<br/>",
+      "Careful harvesting the bush set you on fire, breaking it drops nothing",
       "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make fire resistance potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -229,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:crimson_fire_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Crimson Fire Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Crimson Grape.json
+++ b/config/heracles/quests/farmeroworlds/Crimson Grape.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cristel Wine.json
+++ b/config/heracles/quests/farmeroworlds/Cristel Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Crops and Plants.json
+++ b/config/heracles/quests/farmeroworlds/Crops and Plants.json
@@ -102,6 +102,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Crops and Plants.json
+++ b/config/heracles/quests/farmeroworlds/Crops and Plants.json
@@ -1,0 +1,107 @@
+{
+  "dependencies": [
+    "End's Delight"
+  ],
+  "tasks": {
+    "edcs": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_succulent",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edepg": {
+      "type": "heracles:item",
+      "item": "ends_delight:ender_pearl_grain",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edcfg": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_fruit_grain",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "eddcf": {
+      "type": "heracles:item",
+      "item": "ends_delight:dried_chorus_flower",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "These are some of the more basic ingredients",
+      "<br/>",
+      "<br/>",
+      "Chorus succulents are a new plant that spawns in the End, it can be eaten or used for other recipes, it can be planted on end stone and can grow until having 4 bulbs, dropping 4 succulents when broken",
+      "<br/>",
+      "Chorus fruit grains are obtained by cutting chorus fruit on a cutting board, these can be eaten without causing a teleport or used as an ingredient",
+      "<br/>",
+      "Dried chorus flower is obtained by smelting chorus flower, it will be used as an ingredient",
+      "<br/>",
+      "Ender pearl grains are obtained by cutting an ender pearl in a cutting board, it will be used as an ingredient"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -575,
+          -75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:chorus_succulent",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Crops, Plants and Grains"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Croptopia Crops.json
+++ b/config/heracles/quests/farmeroworlds/Croptopia Crops.json
@@ -101,9 +101,9 @@
         "type": "heracles:item"
       }
     },
-    "cc44": {
+    "cc23": {
       "type": "heracles:item",
-      "item": "croptopia:kiwi",
+      "item": "croptopia:kale",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -115,9 +115,205 @@
         "type": "heracles:item"
       }
     },
-    "cc23": {
+    "cc31": {
       "type": "heracles:item",
-      "item": "croptopia:kale",
+      "item": "croptopia:raspberry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc32": {
+      "type": "heracles:item",
+      "item": "croptopia:rhubarb",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc30": {
+      "type": "heracles:item",
+      "item": "croptopia:radish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc19": {
+      "type": "heracles:item",
+      "item": "croptopia:grape",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc17": {
+      "type": "heracles:item",
+      "item": "croptopia:eggplant",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc18": {
+      "type": "heracles:item",
+      "item": "croptopia:elderberry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc15": {
+      "type": "heracles:item",
+      "item": "croptopia:cucumber",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc16": {
+      "type": "heracles:item",
+      "item": "croptopia:currant",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc13": {
+      "type": "heracles:item",
+      "item": "farmersrespite:coffee_beans",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc14": {
+      "type": "heracles:item",
+      "item": "croptopia:cranberry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc11": {
+      "type": "heracles:item",
+      "item": "croptopia:chile_pepper",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc12": {
+      "type": "heracles:item",
+      "item": "croptopia:corn",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc20": {
+      "type": "heracles:item",
+      "item": "croptopia:greenbean",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc21": {
+      "type": "heracles:item",
+      "item": "croptopia:greenonion",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc44": {
+      "type": "heracles:item",
+      "item": "croptopia:kiwi",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -157,20 +353,6 @@
         "type": "heracles:item"
       }
     },
-    "cc31": {
-      "type": "heracles:item",
-      "item": "croptopia:raspberry",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "cc0": {
       "type": "heracles:item",
       "item": "croptopia:asparagus",
@@ -199,20 +381,6 @@
         "type": "heracles:item"
       }
     },
-    "cc32": {
-      "type": "heracles:item",
-      "item": "croptopia:rhubarb",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "cc3": {
       "type": "heracles:item",
       "item": "croptopia:bellpepper",
@@ -230,20 +398,6 @@
     "cc2": {
       "type": "heracles:item",
       "item": "croptopia:barley",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cc30": {
-      "type": "heracles:item",
-      "item": "croptopia:radish",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -353,23 +507,9 @@
         "type": "heracles:item"
       }
     },
-    "cc19": {
+    "fdc": {
       "type": "heracles:item",
-      "item": "croptopia:grape",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cc17": {
-      "type": "heracles:item",
-      "item": "croptopia:eggplant",
+      "item": "farmersdelight:cabbage",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -395,51 +535,9 @@
         "type": "heracles:item"
       }
     },
-    "cc18": {
-      "type": "heracles:item",
-      "item": "croptopia:elderberry",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cc15": {
-      "type": "heracles:item",
-      "item": "croptopia:cucumber",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "cc37": {
       "type": "heracles:item",
       "item": "croptopia:squash",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cc16": {
-      "type": "heracles:item",
-      "item": "croptopia:currant",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -465,37 +563,9 @@
         "type": "heracles:item"
       }
     },
-    "cc13": {
-      "type": "heracles:item",
-      "item": "farmersrespite:coffee_beans",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "cc35": {
       "type": "heracles:item",
       "item": "croptopia:soybean",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cc14": {
-      "type": "heracles:item",
-      "item": "croptopia:cranberry",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -521,37 +591,9 @@
         "type": "heracles:item"
       }
     },
-    "cc11": {
-      "type": "heracles:item",
-      "item": "croptopia:chile_pepper",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "cc33": {
       "type": "heracles:item",
       "item": "croptopia:rutabaga",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cc12": {
-      "type": "heracles:item",
-      "item": "croptopia:corn",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -577,20 +619,6 @@
         "type": "heracles:item"
       }
     },
-    "cc20": {
-      "type": "heracles:item",
-      "item": "croptopia:greenbean",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "cc42": {
       "type": "heracles:item",
       "item": "croptopia:yam",
@@ -605,9 +633,9 @@
         "type": "heracles:item"
       }
     },
-    "cc21": {
+    "fdo": {
       "type": "heracles:item",
-      "item": "croptopia:greenonion",
+      "item": "farmersdelight:onion",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -650,6 +678,34 @@
     "cc41": {
       "type": "heracles:item",
       "item": "croptopia:turnip",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:rice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdt": {
+      "type": "heracles:item",
+      "item": "farmersdelight:tomato",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",

--- a/config/heracles/quests/farmeroworlds/Croptopia Crops.json
+++ b/config/heracles/quests/farmeroworlds/Croptopia Crops.json
@@ -754,6 +754,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Croptopia Fruits.json
+++ b/config/heracles/quests/farmeroworlds/Croptopia Fruits.json
@@ -387,6 +387,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Croptopia1.json
+++ b/config/heracles/quests/farmeroworlds/Croptopia1.json
@@ -60,6 +60,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Croptopia1.json
+++ b/config/heracles/quests/farmeroworlds/Croptopia1.json
@@ -50,7 +50,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Croptopia"
     }

--- a/config/heracles/quests/farmeroworlds/Crusty Bread.json
+++ b/config/heracles/quests/farmeroworlds/Crusty Bread.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Cupcakes.json
+++ b/config/heracles/quests/farmeroworlds/Cupcakes.json
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bac": {
+    "bsc": {
       "type": "heracles:item",
-      "item": "bakery:apple_cupcake",
+      "item": "bakery:strawberry_cupcake",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "bsc": {
+    "bac": {
       "type": "heracles:item",
-      "item": "bakery:strawberry_cupcake",
+      "item": "bakery:apple_cupcake",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -79,6 +79,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Desserts.json
+++ b/config/heracles/quests/farmeroworlds/Desserts.json
@@ -317,6 +317,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Dolphin Berries.json
+++ b/config/heracles/quests/farmeroworlds/Dolphin Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Dolphin Berries.json
+++ b/config/heracles/quests/farmeroworlds/Dolphin Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbdb": {
+      "type": "heracles:item",
+      "item": "strangeberries:dolphin_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found underwater on warm oceans, lukewarm oceans and deep lukewarm oceans",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be fed to dolphins"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -301,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:dolphin_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Dolphin Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Dragon Leg with Sauce.json
+++ b/config/heracles/quests/farmeroworlds/Dragon Leg with Sauce.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Dragon Leg with Sauce.json
+++ b/config/heracles/quests/farmeroworlds/Dragon Leg with Sauce.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Big Meals"
   ],
   "tasks": {
-    "ed": {
+    "eddlsp": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_leg_with_sauce",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "eddls": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_leg_with_sauce_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,35 +38,26 @@
       "text": ""
     },
     "description": [
-      "Ever found yourself starving in the End with nothing else to eat than annoying chorus fruit? Well now you will have a whole new --dimension-- of thing to eat, with multiple recipes both simple and powerful",
-      "<br/>",
-      "<br/>",
-      "You will also now have a new stove and a few new knives",
-      "<br/>",
-      "<br/>",
-      "You can also use Create to cook these foods"
+      "A 2 block long feast, provides 7 plates of dragon leg with sauce"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -540,
-          -40
+          -610,
+          -135
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "ends_delight:dragon_tooth_knife",
-        "count": 1,
-        "nbt": {
-          "Damage": 0
-        }
+        "id": "ends_delight:dragon_leg_with_sauce_block",
+        "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "End's Delight"
+      "translate": "Dragon Leg with Sauce"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Dragon Meat Stew.json
+++ b/config/heracles/quests/farmeroworlds/Dragon Meat Stew.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Dragon Meat Stew.json
+++ b/config/heracles/quests/farmeroworlds/Dragon Meat Stew.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Big Meals"
   ],
   "tasks": {
-    "ed": {
+    "eddms": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_meat_stew_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "eddmsb": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_meat_stew",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,35 +38,26 @@
       "text": ""
     },
     "description": [
-      "Ever found yourself starving in the End with nothing else to eat than annoying chorus fruit? Well now you will have a whole new --dimension-- of thing to eat, with multiple recipes both simple and powerful",
-      "<br/>",
-      "<br/>",
-      "You will also now have a new stove and a few new knives",
-      "<br/>",
-      "<br/>",
-      "You can also use Create to cook these foods"
+      "It provides 4 bowls of dragon meat stew, after the egg is empty you can get the half dragon egg shell back"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
           -540,
-          -40
+          -135
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "ends_delight:dragon_tooth_knife",
-        "count": 1,
-        "nbt": {
-          "Damage": 0
-        }
+        "id": "ends_delight:dragon_meat_stew_block",
+        "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "End's Delight"
+      "translate": "Dragon Meat Stew"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Drink Making.json
+++ b/config/heracles/quests/farmeroworlds/Drink Making.json
@@ -202,6 +202,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Drink Making.json
+++ b/config/heracles/quests/farmeroworlds/Drink Making.json
@@ -180,8 +180,8 @@
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -630,
-          0
+          -685,
+          50
         ]
       }
     },

--- a/config/heracles/quests/farmeroworlds/Drink Making.json
+++ b/config/heracles/quests/farmeroworlds/Drink Making.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Kettle"
   ],
   "tasks": {
-    "fdsip": {
+    "frpt": {
       "type": "heracles:item",
-      "item": "farmersdelight:squid_ink_pasta",
+      "item": "farmersrespite:purulent_tea",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdts": {
+    "frrht": {
       "type": "heracles:item",
-      "item": "farmersdelight:tomato_sauce",
+      "item": "farmersrespite:rose_hip_tea",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdrp": {
+    "frgtl": {
       "type": "heracles:item",
-      "item": "farmersdelight:raw_pasta",
+      "item": "farmersrespite:green_tea_leaves",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdwd": {
+    "frrh": {
       "type": "heracles:item",
-      "item": "farmersdelight:wheat_dough",
+      "item": "farmersrespite:rose_hips",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "fdpwm": {
+    "frytl": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_meatballs",
+      "item": "farmersrespite:yellow_tea_leaves",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -73,9 +73,9 @@
         "type": "heracles:item"
       }
     },
-    "fdvn": {
+    "frc": {
       "type": "heracles:item",
-      "item": "farmersdelight:vegetable_noodles",
+      "item": "farmersrespite:coffee",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -87,9 +87,9 @@
         "type": "heracles:item"
       }
     },
-    "fdns": {
+    "fryt": {
       "type": "heracles:item",
-      "item": "farmersdelight:noodle_soup",
+      "item": "farmersrespite:yellow_tea",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -101,9 +101,51 @@
         "type": "heracles:item"
       }
     },
-    "fdpwmc": {
+    "frgt": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_mutton_chop",
+      "item": "farmersrespite:green_tea",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frbtl": {
+      "type": "heracles:item",
+      "item": "farmersrespite:black_tea_leaves",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdt": {
+      "type": "heracles:item",
+      "item": "farmersrespite:dandelion_tea",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frbt": {
+      "type": "heracles:item",
+      "item": "farmersrespite:black_tea",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -122,32 +164,37 @@
       "text": ""
     },
     "description": [
-      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
+      "once you have a kettle you will be able to start making drinks in it, but there are a few ingredients you will need first",
       "<br/>",
       "<br/>",
-      "Wheat dough can also be made in multiple ways",
+      "Tea leaves, they are one of the most important things, to obtain them you will need to find a wild tea bush, breaking it will give you tea seeds, with them you can plant your very own tea bush and it doesn't need to be on farmland",
+      "<br/>",
+      "The tea bush will slowly mature through the 3 different tea leaves, starting on green, then yellow and finally black, so if you want green and yellow leaves keep an eye on the tea bush since you can't go back once it has matured",
       "<br/>",
       "<br/>",
-      "You will also want to make some tomato sauce for the more traditional pasta"
+      "Another ingredient is rose hips, these are obtained by cutting a rose on a cutting board",
+      "<br/>",
+      "<br/>",
+      "All drinks work as mini potions they can also have their duration extended or potency increased just like potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          50
+          -630,
+          0
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:raw_pasta",
+        "id": "farmersrespite:green_tea",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Pasta"
+      "translate": "Drink Making"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Drinks ED.json
+++ b/config/heracles/quests/farmeroworlds/Drinks ED.json
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Drinks ED.json
+++ b/config/heracles/quests/farmeroworlds/Drinks ED.json
@@ -1,0 +1,112 @@
+{
+  "dependencies": [
+    "Crops and Plants"
+  ],
+  "tasks": {
+    "edcfmt": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_fruit_milk_tea",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "eddbs": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_breath_soda",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edcfw": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_fruit_wine",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edcft": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_flower_tea",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edbt": {
+      "type": "heracles:item",
+      "item": "ends_delight:bubble_tea",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "A collection of drinks made with End ingredients"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -610,
+          -105
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:dragon_breath_soda",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Drinks ED"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Drinks FRIGHT.json
+++ b/config/heracles/quests/farmeroworlds/Drinks FRIGHT.json
@@ -177,6 +177,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Drinks FRIGHT.json
+++ b/config/heracles/quests/farmeroworlds/Drinks FRIGHT.json
@@ -1,0 +1,182 @@
+{
+  "dependencies": [
+    "Fright's Delight"
+  ],
+  "tasks": {
+    "frdgtpb": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punchbowl_ghasttear",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsbpb": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punchbowl_soul_berry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsep": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punch_spidereye",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsepb": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punchbowl_spidereye",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdgtp": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punch_ghasttear",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdwbp": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punch_wither_berry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdwbpb": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punchbowl_wither_berry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsbp": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punch_soul_berry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsac": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punch_slimeapple",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsacb": {
+      "type": "heracles:item",
+      "item": "frightsdelight:punchbowl_slimeapple",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "These drinks are pretty efficient way of using your ingredients, they can also be made into bowls which can be placed as decoration and can refill your bottles to get back the drink"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -446,
+          100
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "frightsdelight:punch_soul_berry",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Drinks and Bowls"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Drinks.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Farmer's Delight"
   ],
   "tasks": {
-    "bcb": {
+    "fdmj": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_box",
+      "item": "farmersdelight:melon_juice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bct": {
+    "fdmb": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_truffle",
+      "item": "farmersdelight:milk_bottle",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,23 @@
         "type": "heracles:item"
       }
     },
-    "bcs": {
+    "fdhc": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_jam",
+      "item": "farmersdelight:hot_cocoa",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdac": {
+      "type": "heracles:item",
+      "item": "farmersdelight:apple_cider",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +66,29 @@
       "text": ""
     },
     "description": [
-      "Chocolate truffles are quite versatile, they can be eaten, used to cook other things or used to make a chocolate box, the chocolate box can be used as a decoration and you can eat from it by just clicking"
+      "These drinks provides a minor buff, like some kind of simpler potion",
+      "<br/>",
+      "<br/>",
+      "Milk bottles allow to quadruple how much food you can make with a bucket of milk, while clearing an effect"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -160,
-          -240
+          -365,
+          100
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:chocolate_truffle",
+        "id": "farmersdelight:hot_cocoa",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Chocolate Truffle"
+      "translate": "Drinks"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Drinks.json
@@ -96,6 +96,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Eiswein.json
+++ b/config/heracles/quests/farmeroworlds/Eiswein.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/End's Delight.json
+++ b/config/heracles/quests/farmeroworlds/End's Delight.json
@@ -47,7 +47,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "End's Delight"
     }

--- a/config/heracles/quests/farmeroworlds/End's Delight.json
+++ b/config/heracles/quests/farmeroworlds/End's Delight.json
@@ -57,6 +57,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/End's Delight.json
+++ b/config/heracles/quests/farmeroworlds/End's Delight.json
@@ -1,0 +1,39 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {},
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -540,
+          -40
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "minecraft:map",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "End's Delight"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Equipment.json
+++ b/config/heracles/quests/farmeroworlds/Equipment.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Fake Dragon Egg.json
+++ b/config/heracles/quests/farmeroworlds/Fake Dragon Egg.json
@@ -1,0 +1,104 @@
+{
+  "dependencies": [
+    "Meats and Dragon Drops"
+  ],
+  "tasks": {
+    "edlde": {
+      "type": "heracles:item",
+      "item": "ends_delight:liquid_dragon_egg",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edhde": {
+      "type": "heracles:item",
+      "item": "ends_delight:half_dragon_egg_shell",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edfde": {
+      "type": "heracles:item",
+      "item": "ends_delight:fried_dragon_egg",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edde": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_egg_shell",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "The non hatchable dragon egg is a craftable version that can't be placed and serves as an ingredient",
+      "<br/>",
+      "<br/>",
+      "It must be cut in a cutting board using a nether star, but don't worry you won't lose it",
+      "<br/>",
+      "<br/>",
+      "Upon cutting the egg you will get liquid dragon egg a highly nourishing food with some positive effects and a negative one, cooking it is highly recommended since it makes it more nutritious, gets rid of the negative effect and improves the positive ones, you will also get a dragon egg shell from cutting the egg, this can be used to craft a half dragon egg shell which is used for some recipes"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -540,
+          -105
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:non_hatchable_dragon_egg",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Fake Dragon Egg"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Fake Dragon Egg.json
+++ b/config/heracles/quests/farmeroworlds/Fake Dragon Egg.json
@@ -99,6 +99,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Farmer's Delight.json
+++ b/config/heracles/quests/farmeroworlds/Farmer's Delight.json
@@ -44,7 +44,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Farmer's Delight"
     }

--- a/config/heracles/quests/farmeroworlds/Farmer's Delight.json
+++ b/config/heracles/quests/farmeroworlds/Farmer's Delight.json
@@ -54,6 +54,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Farmer's Delight.json
+++ b/config/heracles/quests/farmeroworlds/Farmer's Delight.json
@@ -1,0 +1,59 @@
+{
+  "dependencies": [
+    "An Introduction"
+  ],
+  "tasks": {
+    "fd": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "type": "heracles:check"
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Farmer's Delight adds a vast variety of foods, many of them are highly nutritious, providing a lot of saturation, to cook these foods there are some new systems, mainly the cutting board and cooking pot",
+      "<br/>",
+      "<br/>",
+      "Farmer's Delight also has Create compatibility, you will be able to cook and cut food with it"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -325,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:iron_knife",
+        "count": 1,
+        "nbt": {
+          "Damage": 0
+        }
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Farmer's Delight"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Farmer's Respite.json
+++ b/config/heracles/quests/farmeroworlds/Farmer's Respite.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Farmer's Respite.json
+++ b/config/heracles/quests/farmeroworlds/Farmer's Respite.json
@@ -1,0 +1,56 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fr": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "type": "heracles:check"
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "<br/>",
+      "<br/>",
+      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -540,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersrespite:yellow_tea",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Farmer's Respite"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Farming for Blockheads.json
+++ b/config/heracles/quests/farmeroworlds/Farming for Blockheads.json
@@ -1,13 +1,9 @@
 {
   "dependencies": [
-    "Berries Assemble"
+    "Cooking for Blockheads"
   ],
   "tasks": {
-    "sbhb": {
-      "type": "heracles:item",
-      "item": "strangeberries:haste_berries",
-      "amount": 1,
-      "collection": "AUTOMATIC",
+    "ffb": {
       "title": "",
       "icon": {
         "item": {
@@ -15,7 +11,8 @@
           "count": 0
         },
         "type": "heracles:item"
-      }
+      },
+      "type": "heracles:check"
     }
   },
   "rewards": {},
@@ -24,26 +21,26 @@
       "text": ""
     },
     "description": [
-      "Found underground, grows on stone"
+      "To cook one must first farm, these are a few utilities to help you gather ingredients for your cooking"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -325,
-          185
+          -35,
+          -110
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "strangeberries:haste_berries",
+        "id": "farmingforblockheads:green_fertilizer",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
-      "translate": "Haste Berries"
+      "translate": "Farming for Blockheads"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Feasts for a King.json
+++ b/config/heracles/quests/farmeroworlds/Feasts for a King.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Feasts for a King.json
+++ b/config/heracles/quests/farmeroworlds/Feasts for a King.json
@@ -1,0 +1,53 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdffk": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "type": "heracles:check"
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Farmer's Delight also adds a few foods that can only be placed down and picked with a bowl, they are highly nourishing"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -415,
+          -40
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:canvas_sign",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Feasts for a King"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Fertilizers.json
+++ b/config/heracles/quests/farmeroworlds/Fertilizers.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Feasts for a King"
+    "Farming for Blockheads"
   ],
   "tasks": {
-    "fdh": {
+    "ffbgf": {
       "type": "heracles:item",
-      "item": "farmersdelight:ham",
+      "item": "farmingforblockheads:green_fertilizer",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdsh": {
+    "ffbyf": {
       "type": "heracles:item",
-      "item": "farmersdelight:smoked_ham",
+      "item": "farmingforblockheads:yellow_fertilizer",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,23 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdhgh": {
+    "ffbrf": {
       "type": "heracles:item",
-      "item": "farmersdelight:honey_glazed_ham_block",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdhghb": {
-      "type": "heracles:item",
-      "item": "farmersdelight:honey_glazed_ham",
+      "item": "farmingforblockheads:red_fertilizer",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -66,26 +52,33 @@
       "text": ""
     },
     "description": [
-      "Can fill up to 4 bowls, ham is obtained by killing pigs or hoglins with a knife, it can only be cooked in a smoker"
+      "Fertilizers help your crops",
+      "<br/>",
+      "<br/>",
+      "/a/Green/a/ fertilizer makes crops give more produce than normal",
+      "<br/>",
+      "/c/Red/c/ fertilizer makes crops grow faster",
+      "<br/>",
+      "/e/Yellow/e/ fertilizer prevents crops from being destroyed when someone jumps in them, it can also be mixed with one of the other fertilizers"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -415,
-          -85
+          -50,
+          -135
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:honey_glazed_ham_block",
+        "id": "farmingforblockheads:red_fertilizer",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Honey Glazed Ham"
+      "translate": "Fertilizers"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Fiery Fondue Pot.json
+++ b/config/heracles/quests/farmeroworlds/Fiery Fondue Pot.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Fiery Fondue Pot.json
+++ b/config/heracles/quests/farmeroworlds/Fiery Fondue Pot.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Cheese Making"
   ],
   "tasks": {
-    "fr": {
+    "bcffp": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:fiery_fondue_pot",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "bcff": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:fiery_fondue",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +38,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "The fiery fondue pot is a cauldron full of food that can be placed down, it will fill 3 bowls and leave the cauldron behind"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -775,
+          -60
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "brewinandchewin:fiery_fondue_pot",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Fiery Fondue Pot"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Fish Rolls.json
+++ b/config/heracles/quests/farmeroworlds/Fish Rolls.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Fish Rolls.json
+++ b/config/heracles/quests/farmeroworlds/Fish Rolls.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Fish Slices"
   ],
   "tasks": {
-    "fdsip": {
+    "ndscr": {
       "type": "heracles:item",
-      "item": "farmersdelight:squid_ink_pasta",
+      "item": "netherdepthsupgrade:searing_cod_roll",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdts": {
+    "ndmcfr": {
       "type": "heracles:item",
-      "item": "farmersdelight:tomato_sauce",
+      "item": "netherdepthsupgrade:magmacubefish_roll",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdrp": {
+    "ndgr": {
       "type": "heracles:item",
-      "item": "farmersdelight:raw_pasta",
+      "item": "netherdepthsupgrade:glowdine_roll",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdwd": {
+    "ndlpr": {
       "type": "heracles:item",
-      "item": "farmersdelight:wheat_dough",
+      "item": "netherdepthsupgrade:lava_pufferfish_roll",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "fdpwm": {
+    "ndbr": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_meatballs",
+      "item": "netherdepthsupgrade:blazefish_roll",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -73,9 +73,9 @@
         "type": "heracles:item"
       }
     },
-    "fdvn": {
+    "ndsr": {
       "type": "heracles:item",
-      "item": "farmersdelight:vegetable_noodles",
+      "item": "netherdepthsupgrade:soulsucker_roll",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -87,23 +87,9 @@
         "type": "heracles:item"
       }
     },
-    "fdns": {
+    "ndor": {
       "type": "heracles:item",
-      "item": "farmersdelight:noodle_soup",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdpwmc": {
-      "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_mutton_chop",
+      "item": "netherdepthsupgrade:obsidianfish_roll",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -122,32 +108,26 @@
       "text": ""
     },
     "description": [
-      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
-      "<br/>",
-      "<br/>",
-      "Wheat dough can also be made in multiple ways",
-      "<br/>",
-      "<br/>",
-      "You will also want to make some tomato sauce for the more traditional pasta"
+      "Another simple alternative to fish slices, simply add rice for a bit extra nourishment"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          50
+          -615,
+          95
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:raw_pasta",
+        "id": "netherdepthsupgrade:searing_cod_roll",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Pasta"
+      "translate": "Fish Rolls"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Fish Slices.json
+++ b/config/heracles/quests/farmeroworlds/Fish Slices.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "The Fish"
   ],
   "tasks": {
-    "fdsip": {
+    "ndscs": {
       "type": "heracles:item",
-      "item": "farmersdelight:squid_ink_pasta",
+      "item": "netherdepthsupgrade:searing_cod_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdts": {
+    "ndmcfs": {
       "type": "heracles:item",
-      "item": "farmersdelight:tomato_sauce",
+      "item": "netherdepthsupgrade:magmacubefish_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdrp": {
+    "ndgs": {
       "type": "heracles:item",
-      "item": "farmersdelight:raw_pasta",
+      "item": "netherdepthsupgrade:glowdine_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdwd": {
+    "ndlps": {
       "type": "heracles:item",
-      "item": "farmersdelight:wheat_dough",
+      "item": "netherdepthsupgrade:lava_pufferfish_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "fdpwm": {
+    "ndbs": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_meatballs",
+      "item": "netherdepthsupgrade:blazefish_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -73,9 +73,9 @@
         "type": "heracles:item"
       }
     },
-    "fdvn": {
+    "ndss": {
       "type": "heracles:item",
-      "item": "farmersdelight:vegetable_noodles",
+      "item": "netherdepthsupgrade:soulsucker_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -87,23 +87,9 @@
         "type": "heracles:item"
       }
     },
-    "fdns": {
+    "ndos": {
       "type": "heracles:item",
-      "item": "farmersdelight:noodle_soup",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdpwmc": {
-      "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_mutton_chop",
+      "item": "netherdepthsupgrade:obsidianfish_slice",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -122,32 +108,26 @@
       "text": ""
     },
     "description": [
-      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
-      "<br/>",
-      "<br/>",
-      "Wheat dough can also be made in multiple ways",
-      "<br/>",
-      "<br/>",
-      "You will also want to make some tomato sauce for the more traditional pasta"
+      "Slicing the fish in a cutting board allows to get more out of them and you will also need these slices for better recipes"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          50
+          -580,
+          110
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:raw_pasta",
+        "id": "netherdepthsupgrade:searing_cod_slice",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Pasta"
+      "translate": "Fish Slices"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Fish Slices.json
+++ b/config/heracles/quests/farmeroworlds/Fish Slices.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Fishing & Croptopia.json
+++ b/config/heracles/quests/farmeroworlds/Fishing & Croptopia.json
@@ -149,6 +149,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Foods.json
+++ b/config/heracles/quests/farmeroworlds/Foods.json
@@ -191,6 +191,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Foods.json
+++ b/config/heracles/quests/farmeroworlds/Foods.json
@@ -1,0 +1,196 @@
+{
+  "dependencies": [
+    "Fright's Delight"
+  ],
+  "tasks": {
+    "frdsa": {
+      "type": "heracles:item",
+      "item": "frightsdelight:apple_slime",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdrfs": {
+      "type": "heracles:item",
+      "item": "frightsdelight:soup_rotten_flesh",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdrfc": {
+      "type": "heracles:item",
+      "item": "frightsdelight:cookie_flesh",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdrcs": {
+      "type": "heracles:item",
+      "item": "frightsdelight:web_on_stick",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdmm": {
+      "type": "heracles:item",
+      "item": "frightsdelight:monster_mash",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdss": {
+      "type": "heracles:item",
+      "item": "frightsdelight:pasta_with_slimeballs",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdses": {
+      "type": "heracles:item",
+      "item": "frightsdelight:soup_spider_eye",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsec": {
+      "type": "heracles:item",
+      "item": "frightsdelight:cookie_spidereye",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frduk": {
+      "type": "heracles:item",
+      "item": "frightsdelight:undead_kebab",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsbs": {
+      "type": "heracles:item",
+      "item": "frightsdelight:soup_slime",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "frdsbc": {
+      "type": "heracles:item",
+      "item": "frightsdelight:cookie_soul_berry",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Most of these foods will have mild negative effects, mainly just hearing the cries of the dead, but don't worry they can just be ignored or you can eat or drink something made with berries which will make you immune to it"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -470,
+          75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "frightsdelight:apple_slime",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Foods"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Fright's Delight.json
+++ b/config/heracles/quests/farmeroworlds/Fright's Delight.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Fright's Delight.json
+++ b/config/heracles/quests/farmeroworlds/Fright's Delight.json
@@ -3,7 +3,7 @@
     "Farmer's Delight"
   ],
   "tasks": {
-    "fr": {
+    "fd": {
       "title": "",
       "icon": {
         "item": {
@@ -21,29 +21,29 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Tired of dealing with hostile mobs? Have an excess of their loot? Well now you can eat their remains out of pure spite! Certainly it can't be unhealthy, right?",
       "<br/>",
       "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "You will also be able to use Create for these recipes"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -445,
+          40
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "minecraft:ghast_tear",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Fright's Delight"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Frigid Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Frigid Drinks.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Frigid Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Frigid Drinks.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "The Keg"
   ],
   "tasks": {
-    "fr": {
+    "bcdn": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:dread_nog",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "bcsts": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:steel_toe_stout",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +38,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "A collection of drinks made with a frigid keg"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -735,
+          -90
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "brewinandchewin:steel_toe_stout",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Frigid Drinks"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Ghastly Grenache.json
+++ b/config/heracles/quests/farmeroworlds/Ghastly Grenache.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Glowberry Tart.json
+++ b/config/heracles/quests/farmeroworlds/Glowberry Tart.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Golden Berries.json
+++ b/config/heracles/quests/farmeroworlds/Golden Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Golden Berries.json
+++ b/config/heracles/quests/farmeroworlds/Golden Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbgb": {
+      "type": "heracles:item",
+      "item": "strangeberries:golden_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Can only be crafted",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make luck potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -349,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:golden_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Golden Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Grapes.json
+++ b/config/heracles/quests/farmeroworlds/Grapes.json
@@ -36,6 +36,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Grapevine Pot.json
+++ b/config/heracles/quests/farmeroworlds/Grapevine Pot.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Grapevine Stem.json
+++ b/config/heracles/quests/farmeroworlds/Grapevine Stem.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Grilled Fish.json
+++ b/config/heracles/quests/farmeroworlds/Grilled Fish.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "The Fish"
   ],
   "tasks": {
-    "fdsip": {
+    "ndgs": {
       "type": "heracles:item",
-      "item": "farmersdelight:squid_ink_pasta",
+      "item": "netherdepthsupgrade:grilled_soulsucker",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdts": {
+    "ndgb": {
       "type": "heracles:item",
-      "item": "farmersdelight:tomato_sauce",
+      "item": "netherdepthsupgrade:grilled_blazefish",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdrp": {
+    "ndgg": {
       "type": "heracles:item",
-      "item": "farmersdelight:raw_pasta",
+      "item": "netherdepthsupgrade:grilled_glowdine",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdwd": {
+    "ndglp": {
       "type": "heracles:item",
-      "item": "farmersdelight:wheat_dough",
+      "item": "netherdepthsupgrade:grilled_lava_pufferfish",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "fdpwm": {
+    "ndgmcf": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_meatballs",
+      "item": "netherdepthsupgrade:grilled_magmacubefish",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -73,9 +73,9 @@
         "type": "heracles:item"
       }
     },
-    "fdvn": {
+    "ndgsc": {
       "type": "heracles:item",
-      "item": "farmersdelight:vegetable_noodles",
+      "item": "netherdepthsupgrade:grilled_searing_cod",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -87,23 +87,9 @@
         "type": "heracles:item"
       }
     },
-    "fdns": {
+    "ndgo": {
       "type": "heracles:item",
-      "item": "farmersdelight:noodle_soup",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdpwmc": {
-      "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_mutton_chop",
+      "item": "netherdepthsupgrade:grilled_obsidianfish",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -122,32 +108,26 @@
       "text": ""
     },
     "description": [
-      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
-      "<br/>",
-      "<br/>",
-      "Wheat dough can also be made in multiple ways",
-      "<br/>",
-      "<br/>",
-      "You will also want to make some tomato sauce for the more traditional pasta"
+      "Grilled fish dishes are a highly nourishing way of preparing your fish"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          50
+          -540,
+          110
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:raw_pasta",
+        "id": "netherdepthsupgrade:grilled_searing_cod",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Pasta"
+      "translate": "Grilled Fish"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Grilled Fish.json
+++ b/config/heracles/quests/farmeroworlds/Grilled Fish.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Grilled Shulker.json
+++ b/config/heracles/quests/farmeroworlds/Grilled Shulker.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Grilled Shulker.json
+++ b/config/heracles/quests/farmeroworlds/Grilled Shulker.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Big Meals"
   ],
   "tasks": {
-    "ed": {
+    "edgs": {
+      "type": "heracles:item",
+      "item": "ends_delight:grilled_shulker_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "edgsp": {
+      "type": "heracles:item",
+      "item": "ends_delight:grilled_shulker",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,35 +38,26 @@
       "text": ""
     },
     "description": [
-      "Ever found yourself starving in the End with nothing else to eat than annoying chorus fruit? Well now you will have a whole new --dimension-- of thing to eat, with multiple recipes both simple and powerful",
-      "<br/>",
-      "<br/>",
-      "You will also now have a new stove and a few new knives",
-      "<br/>",
-      "<br/>",
-      "You can also use Create to cook these foods"
+      "It provides 4 plates of grilled shulker, after the shulker is empty you can get the shulker shell back"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -540,
-          -40
+          -560,
+          -160
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "ends_delight:dragon_tooth_knife",
-        "count": 1,
-        "nbt": {
-          "Damage": 0
-        }
+        "id": "ends_delight:grilled_shulker_block",
+        "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "End's Delight"
+      "translate": "Grilled Shulker"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Hamburgers.json
+++ b/config/heracles/quests/farmeroworlds/Hamburgers.json
@@ -82,6 +82,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Haste Berries.json
+++ b/config/heracles/quests/farmeroworlds/Haste Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbhb": {
+      "type": "heracles:item",
+      "item": "strangeberries:haste_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Found underground, grows on stone"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -325,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:haste_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Haste Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Healing Berries.json
+++ b/config/heracles/quests/farmeroworlds/Healing Berries.json
@@ -55,6 +55,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Healing Berries.json
+++ b/config/heracles/quests/farmeroworlds/Healing Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbhb": {
+      "type": "heracles:item",
+      "item": "strangeberries:healing_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,30 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found in meadows, flower forests and cherry groves",
       "<br/>",
+      "Must be harvested from fruitful berry bushes, walking on the bush restores health",
       "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make healing potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -229,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:healing_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Healing Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Honey Cocktail.json
+++ b/config/heracles/quests/farmeroworlds/Honey Cocktail.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Honey Glazed Ham.json
+++ b/config/heracles/quests/farmeroworlds/Honey Glazed Ham.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Feasts for a King"
   ],
   "tasks": {
-    "bcb": {
+    "fdh": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_box",
+      "item": "farmersdelight:ham",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bct": {
+    "fdsh": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_truffle",
+      "item": "farmersdelight:smoked_ham",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,23 @@
         "type": "heracles:item"
       }
     },
-    "bcs": {
+    "fdhgh": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_jam",
+      "item": "farmersdelight:honey_glazed_ham_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdhghb": {
+      "type": "heracles:item",
+      "item": "farmersdelight:honey_glazed_ham",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +66,26 @@
       "text": ""
     },
     "description": [
-      "Chocolate truffles are quite versatile, they can be eaten, used to cook other things or used to make a chocolate box, the chocolate box can be used as a decoration and you can eat from it by just clicking"
+      "Can fill up to 4 bowls, ham is obtained by killing pigs or hoglins with a knife, it can only be cooked in a smoker"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -160,
-          -240
+          -415,
+          -85
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:chocolate_truffle",
+        "id": "farmersdelight:honey_glazed_ham_block",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Chocolate Truffle"
+      "translate": "Honey Glazed Ham"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Hot Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Hot Drinks.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Hot Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Hot Drinks.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "The Keg"
   ],
   "tasks": {
-    "fr": {
+    "bcwd": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:withering_dross",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "bcrr": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:red_rum",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +38,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "A collection of drinks made with a hot keg"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -635,
+          -90
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "brewinandchewin:red_rum",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Hot Drinks"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Ice Creams.json
+++ b/config/heracles/quests/farmeroworlds/Ice Creams.json
@@ -121,6 +121,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Improved Lava Fizz.json
+++ b/config/heracles/quests/farmeroworlds/Improved Lava Fizz.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Improved Nether Fizz.json
+++ b/config/heracles/quests/farmeroworlds/Improved Nether Fizz.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Industrial Farming.json
+++ b/config/heracles/quests/farmeroworlds/Industrial Farming.json
@@ -1,0 +1,546 @@
+{
+  "dependencies": [
+    "An Introduction"
+  ],
+  "tasks": {
+    "bc": {
+      "type": "heracles:item",
+      "item": "blockus:beetroot_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cobc": {
+      "type": "heracles:item",
+      "item": "frightsdelight:web_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "gcc": {
+      "type": "heracles:item",
+      "item": "blockus:golden_carrot_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bonec": {
+      "type": "heracles:item",
+      "item": "frightsdelight:bone_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "pmc": {
+      "type": "heracles:item",
+      "item": "frightsdelight:phantom_crate",
+      "amount": 100,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "gac": {
+      "type": "heracles:item",
+      "item": "blockus:golden_apple_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bo": {
+      "type": "heracles:item",
+      "item": "bakery:oat_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "sc": {
+      "type": "heracles:item",
+      "item": "blockus:salmon_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bche": {
+      "type": "heracles:item",
+      "item": "vinery:cherry_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bc2": {
+      "type": "heracles:item",
+      "item": "farmersdelight:beetroot_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "sec": {
+      "type": "heracles:item",
+      "item": "frightsdelight:spider_eye_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bs": {
+      "type": "heracles:item",
+      "item": "bakery:strawberry_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "wgc": {
+      "type": "heracles:item",
+      "item": "nethervinery:warped_grape_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc2": {
+      "type": "heracles:item",
+      "item": "farmersdelight:carrot_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "oc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:onion_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bpg": {
+      "type": "heracles:item",
+      "item": "vinery:red_grape_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "potc": {
+      "type": "heracles:item",
+      "item": "blockus:potato_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fsec": {
+      "type": "heracles:item",
+      "item": "frightsdelight:fermented_spider_eye_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "pc2": {
+      "type": "heracles:item",
+      "item": "farmersdelight:potato_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cc": {
+      "type": "heracles:item",
+      "item": "blockus:cod_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "rtc": {
+      "type": "heracles:item",
+      "item": "frightsdelight:rotten_tomato_crate",
+      "amount": 100,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cfc": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_fruit_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ac": {
+      "type": "heracles:item",
+      "item": "blockus:apple_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ppc": {
+      "type": "heracles:item",
+      "item": "frightsdelight:poisonous_potato_crate",
+      "amount": 100,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "carrc": {
+      "type": "heracles:item",
+      "item": "blockus:carrot_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "gbc": {
+      "type": "heracles:item",
+      "item": "blockus:glow_berries_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "tc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:tomato_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "tfc": {
+      "type": "heracles:item",
+      "item": "blockus:tropical_fish_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cabc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cabbage_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "rc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:rice_bag",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "pc": {
+      "type": "heracles:item",
+      "item": "blockus:pufferfish_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bwg": {
+      "type": "heracles:item",
+      "item": "vinery:white_grape_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "sbc": {
+      "type": "heracles:item",
+      "item": "blockus:sweet_berries_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fc": {
+      "type": "heracles:item",
+      "item": "frightsdelight:flesh_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "cgc": {
+      "type": "heracles:item",
+      "item": "nethervinery:crimson_grape_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ba": {
+      "type": "heracles:item",
+      "item": "vinery:apple_crate",
+      "amount": 1000,
+      "collection": "MANUAL",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Farming by hand is a thing of the past, for this challenge you will most likely want to find some way to automate farming, show everyone what a true farmer can achieve"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          35,
+          -115
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "blockus:sweet_berries_crate",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/gears.png",
+    "title": {
+      "translate": "Industrial Farming"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": false,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "IN_PROGRESS"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Ingredient Duplication.json
+++ b/config/heracles/quests/farmeroworlds/Ingredient Duplication.json
@@ -1,0 +1,154 @@
+{
+  "dependencies": [
+    "Cooking Tools"
+  ],
+  "tasks": {
+    "fdrb": {
+      "type": "heracles:item",
+      "item": "farmersdelight:bacon",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdrmc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:mutton_chops",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcl": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cabbage_leaf",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdrcc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:chicken_cuts",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdrcs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cod_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdrss": {
+      "type": "heracles:item",
+      "item": "farmersdelight:salmon_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdmb": {
+      "type": "heracles:item",
+      "item": "farmersdelight:minced_beef",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdps": {
+      "type": "heracles:item",
+      "item": "farmersdelight:pumpkin_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Tired of constantly waiting for crops and animals to grow for your recipes? Well in that case the cutting board can help you, the cutting board will allow to basically duplicate all meats and some vegetables, where before you only had 1 steak for your recipes now you can have 2 for free!"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -325,
+          -70
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:minced_beef",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Ingredient Duplication"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Ingredient Duplication.json
+++ b/config/heracles/quests/farmeroworlds/Ingredient Duplication.json
@@ -149,6 +149,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Invisibility Berries.json
+++ b/config/heracles/quests/farmeroworlds/Invisibility Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Invisibility Berries.json
+++ b/config/heracles/quests/farmeroworlds/Invisibility Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbib": {
+      "type": "heracles:item",
+      "item": "strangeberries:invisibility_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found in ancient cities on skulk or deepslate",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make invisibility potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -205,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:invisibility_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Invisibility Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Jam.json
+++ b/config/heracles/quests/farmeroworlds/Jam.json
@@ -85,8 +85,8 @@
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -75,
-          -250
+          -74,
+          -240
         ]
       }
     },
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Jams.json
+++ b/config/heracles/quests/farmeroworlds/Jams.json
@@ -177,6 +177,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Jellie Wine.json
+++ b/config/heracles/quests/farmeroworlds/Jellie Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Jo's Special mixture.json
+++ b/config/heracles/quests/farmeroworlds/Jo's Special mixture.json
@@ -54,6 +54,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Juices.json
+++ b/config/heracles/quests/farmeroworlds/Juices.json
@@ -177,6 +177,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Kelp Cider.json
+++ b/config/heracles/quests/farmeroworlds/Kelp Cider.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Kettle.json
+++ b/config/heracles/quests/farmeroworlds/Kettle.json
@@ -54,6 +54,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Kettle.json
+++ b/config/heracles/quests/farmeroworlds/Kettle.json
@@ -32,8 +32,8 @@
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -585,
-          0
+          -685,
+          15
         ]
       }
     },

--- a/config/heracles/quests/farmeroworlds/Kettle.json
+++ b/config/heracles/quests/farmeroworlds/Kettle.json
@@ -1,0 +1,59 @@
+{
+  "dependencies": [
+    "Farmer's Respite"
+  ],
+  "tasks": {
+    "frk": {
+      "type": "heracles:item",
+      "item": "farmersrespite:kettle",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "The kettle is your way to make all the drinks, some teas require filling it with water",
+      "<br/>",
+      "<br/>",
+      "The kettles must have a heat source under it, a stove will work perfectly for that"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -585,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersrespite:kettle",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Kettle"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Lattice.json
+++ b/config/heracles/quests/farmeroworlds/Lattice.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Lava Fizz.json
+++ b/config/heracles/quests/farmeroworlds/Lava Fizz.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Lava Glass.json
+++ b/config/heracles/quests/farmeroworlds/Lava Glass.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Lava Glass.json
+++ b/config/heracles/quests/farmeroworlds/Lava Glass.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "The Fish"
   ],
   "tasks": {
-    "ed": {
+    "ndlg": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:lava_glass",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,35 +24,26 @@
       "text": ""
     },
     "description": [
-      "Ever found yourself starving in the End with nothing else to eat than annoying chorus fruit? Well now you will have a whole new --dimension-- of thing to eat, with multiple recipes both simple and powerful",
-      "<br/>",
-      "<br/>",
-      "You will also now have a new stove and a few new knives",
-      "<br/>",
-      "<br/>",
-      "You can also use Create to cook these foods"
+      "Lava glass allows to completely see through lava, it will be useful for finding fish in the nether, ores under lava pools or to simply have a lava aquarium"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -540,
-          -40
+          -500,
+          75
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "ends_delight:dragon_tooth_knife",
-        "count": 1,
-        "nbt": {
-          "Damage": 0
-        }
+        "id": "netherdepthsupgrade:lava_glass",
+        "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "End's Delight"
+      "translate": "Lava Glass"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Lava Sponges.json
+++ b/config/heracles/quests/farmeroworlds/Lava Sponges.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Lava Sponges.json
+++ b/config/heracles/quests/farmeroworlds/Lava Sponges.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Nether Depths"
   ],
   "tasks": {
-    "ed": {
+    "ndls": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:lava_sponge",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,35 +24,26 @@
       "text": ""
     },
     "description": [
-      "Ever found yourself starving in the End with nothing else to eat than annoying chorus fruit? Well now you will have a whole new --dimension-- of thing to eat, with multiple recipes both simple and powerful",
-      "<br/>",
-      "<br/>",
-      "You will also now have a new stove and a few new knives",
-      "<br/>",
-      "<br/>",
-      "You can also use Create to cook these foods"
+      "Lava sponges can be found in big clusters of them in the nether lava oceans, to dry them they must be placed under a block of water, once no longer wet they can be used to erase lava from an area"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -540,
-          -40
+          -500,
+          50
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "ends_delight:dragon_tooth_knife",
-        "count": 1,
-        "nbt": {
-          "Damage": 0
-        }
+        "id": "netherdepthsupgrade:lava_sponge",
+        "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "End's Delight"
+      "translate": "Lava Sponges"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Leaping Berries.json
+++ b/config/heracles/quests/farmeroworlds/Leaping Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Leaping Berries.json
+++ b/config/heracles/quests/farmeroworlds/Leaping Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sblb": {
+      "type": "heracles:item",
+      "item": "strangeberries:leaping_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found on jungles, bamboo jungles, sparse jungles and mangrove swamps",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make a jump boost potion"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -277,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:leaping_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Leaping Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Let's Do Mods.json
+++ b/config/heracles/quests/farmeroworlds/Let's Do Mods.json
@@ -41,7 +41,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Let's Do Mods"
     }

--- a/config/heracles/quests/farmeroworlds/Let's Do Mods.json
+++ b/config/heracles/quests/farmeroworlds/Let's Do Mods.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Linzer Tart.json
+++ b/config/heracles/quests/farmeroworlds/Linzer Tart.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Magnetic Wine.json
+++ b/config/heracles/quests/farmeroworlds/Magnetic Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Market.json
+++ b/config/heracles/quests/farmeroworlds/Market.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Berries Assemble"
+    "Farming for Blockheads"
   ],
   "tasks": {
-    "sbhb": {
+    "ffbm": {
       "type": "heracles:item",
-      "item": "strangeberries:haste_berries",
+      "item": "farmingforblockheads:market",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -24,26 +24,26 @@
       "text": ""
     },
     "description": [
-      "Found underground, grows on stone"
+      "A place for all your crop and tree needs, all sorts of seeds and saplings can be bought here for the low price of one emerald"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -325,
-          185
+          -20,
+          -135
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "strangeberries:haste_berries",
+        "id": "farmingforblockheads:market",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Haste Berries"
+      "translate": "Market"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Mead.json
+++ b/config/heracles/quests/farmeroworlds/Mead.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Meat Recipes.json
+++ b/config/heracles/quests/farmeroworlds/Meat Recipes.json
@@ -93,6 +93,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Meat Recipes.json
+++ b/config/heracles/quests/farmeroworlds/Meat Recipes.json
@@ -1,0 +1,98 @@
+{
+  "dependencies": [
+    "Meats and Dragon Drops"
+  ],
+  "tasks": {
+    "edebs": {
+      "type": "heracles:item",
+      "item": "ends_delight:end_barbecue_stick",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edec": {
+      "type": "heracles:item",
+      "item": "ends_delight:ender_congee",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edsfsm": {
+      "type": "heracles:item",
+      "item": "ends_delight:stir_fried_shulker_meat",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edrds": {
+      "type": "heracles:item",
+      "item": "ends_delight:roasted_dragon_steak",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "These are recipes that use the meats from the End, some require cooked meat others can be made with raw meat"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -505,
+          -105
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:roasted_dragon_steak",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Meat Recipes"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Meats and Dragon Drops.json
+++ b/config/heracles/quests/farmeroworlds/Meats and Dragon Drops.json
@@ -150,6 +150,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Meats and Dragon Drops.json
+++ b/config/heracles/quests/farmeroworlds/Meats and Dragon Drops.json
@@ -1,0 +1,155 @@
+{
+  "dependencies": [
+    "End's Delight"
+  ],
+  "tasks": {
+    "eddt": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_tooth",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edrdm": {
+      "type": "heracles:item",
+      "item": "ends_delight:raw_dragon_meat",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edsms": {
+      "type": "heracles:item",
+      "item": "ends_delight:shulker_meat_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edrem": {
+      "type": "heracles:item",
+      "item": "ends_delight:raw_ender_mite_meat",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edsm": {
+      "type": "heracles:item",
+      "item": "ends_delight:shulker_meat",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "eddl": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_leg",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edrdmc": {
+      "type": "heracles:item",
+      "item": "ends_delight:raw_dragon_meat_cuts",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "These will be the tough ingredients to get, to get all of these drops you will need to kill the mobs with a Farmer's Delight or End's Delight knife, we recommend the netherite or dragon's tooth knife enchanted with sharpness and looting, only the final blow needs to be from a knife",
+      "<br/>",
+      "<br/>",
+      "Dragon tooth is used for making a strong knife or a non hatchable dragon egg which will be used for many recipes",
+      "<br/>",
+      "Shulker meat is used for many recipes",
+      "<br/>",
+      "Shulker meat slices are obtained by cutting shulker meat on a cutting board",
+      "<br/>",
+      "Dragon legs are used for some really nourishing recipes",
+      "<br/>",
+      "Raw dragon meat can be obtained by killing the dragon with a knife or by cutting a dragon leg on a cutting board",
+      "<br/>",
+      "Raw dragon meat cuts are obtained by cutting raw dragon meat on a cutting board",
+      "<br/>",
+      "Raw endermite meat is used for some recipes"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -540,
+          -75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:dragon_leg",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Meats and Dragon Drops"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Mellohi Wine.json
+++ b/config/heracles/quests/farmeroworlds/Mellohi Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Melon Cocktail.json
+++ b/config/heracles/quests/farmeroworlds/Melon Cocktail.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Mexican Cuisine.json
+++ b/config/heracles/quests/farmeroworlds/Mexican Cuisine.json
@@ -289,6 +289,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Milkshakes.json
+++ b/config/heracles/quests/farmeroworlds/Milkshakes.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Kettle"
+    "Tiki Bar"
   ],
   "tasks": {
-    "frgtc": {
+    "bpcm0": {
       "type": "heracles:item",
-      "item": "farmersrespite:green_tea_cookie",
+      "item": "beachparty:chocolate_milkshake",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc0": {
+    "bpsm": {
       "type": "heracles:item",
-      "item": "farmersrespite:black_cod",
+      "item": "beachparty:sweetberry_milkshake",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,37 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "frtc": {
+    "bpcm": {
       "type": "heracles:item",
-      "item": "farmersrespite:tea_curry",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "frnws": {
-      "type": "heracles:item",
-      "item": "farmersrespite:nether_wart_sourdough",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "frbc": {
-      "type": "heracles:item",
-      "item": "farmersrespite:blazing_chili",
+      "item": "beachparty:coconut_milkshake",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -80,26 +52,26 @@
       "text": ""
     },
     "description": [
-      "These are some foods made with ingredients used to make the teas and coffee"
+      "Milkshakes are a combination of milk and sundae made in a tiki bar"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -650,
-          50
+          70,
+          -290
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:blazing_chili",
+        "id": "beachparty:sweetberry_milkshake",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Other Foods"
+      "translate": "Milkshakes"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Milkshakes.json
+++ b/config/heracles/quests/farmeroworlds/Milkshakes.json
@@ -79,6 +79,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Mini Fridge.json
+++ b/config/heracles/quests/farmeroworlds/Mini Fridge.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Miscellaneous Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Miscellaneous Drinks.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Miscellaneous Pastries.json
+++ b/config/heracles/quests/farmeroworlds/Miscellaneous Pastries.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Miss Lilitus Wine.json
+++ b/config/heracles/quests/farmeroworlds/Miss Lilitus Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Multiblock Kitchen.json
+++ b/config/heracles/quests/farmeroworlds/Multiblock Kitchen.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Croptopia1"
+    "Cooking for Blockheads"
   ],
   "tasks": {
-    "cf": {
+    "cfbct": {
       "type": "heracles:item",
-      "item": "croptopia:olive_oil",
+      "item": "cookingforblockheads:cooking_table",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "cf14": {
+    "cfbcj": {
       "type": "heracles:item",
-      "item": "croptopia:fish_and_chips",
+      "item": "cookingforblockheads:cow_jar",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "cf12": {
+    "cfbkc": {
       "type": "heracles:item",
-      "item": "croptopia:stir_fry",
+      "item": "cookingforblockheads:counter",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "cf13": {
+    "cfbpu": {
       "type": "heracles:item",
-      "item": "croptopia:egg_roll",
+      "item": "cookingforblockheads:preservation_chamber",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "cf0": {
+    "cfbkf": {
       "type": "heracles:item",
-      "item": "croptopia:kale_chips",
+      "item": "cookingforblockheads:white_kitchen_floor",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -73,9 +73,9 @@
         "type": "heracles:item"
       }
     },
-    "cf10": {
+    "cfbf": {
       "type": "heracles:item",
-      "item": "croptopia:butter",
+      "item": "cookingforblockheads:fridge",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -87,9 +87,9 @@
         "type": "heracles:item"
       }
     },
-    "cf11": {
+    "cfbs": {
       "type": "heracles:item",
-      "item": "croptopia:beef_stir_fry",
+      "item": "cookingforblockheads:sink",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -101,9 +101,9 @@
         "type": "heracles:item"
       }
     },
-    "cf2": {
+    "cfbt": {
       "type": "heracles:item",
-      "item": "croptopia:french_fries",
+      "item": "cookingforblockheads:toaster",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -115,9 +115,9 @@
         "type": "heracles:item"
       }
     },
-    "cf1": {
+    "cfbfu": {
       "type": "heracles:item",
-      "item": "croptopia:potato_chips",
+      "item": "cookingforblockheads:ice_unit",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -129,9 +129,9 @@
         "type": "heracles:item"
       }
     },
-    "cf4": {
+    "cfbo": {
       "type": "heracles:item",
-      "item": "croptopia:onion_rings",
+      "item": "cookingforblockheads:oven",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -143,79 +143,9 @@
         "type": "heracles:item"
       }
     },
-    "cf3": {
+    "cfbtr": {
       "type": "heracles:item",
-      "item": "croptopia:sweet_potato_fries",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cf6": {
-      "type": "heracles:item",
-      "item": "croptopia:deep_fried_shrimp",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cf5": {
-      "type": "heracles:item",
-      "item": "croptopia:fried_chicken",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cf8": {
-      "type": "heracles:item",
-      "item": "croptopia:dauphine_potatoes",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cf7": {
-      "type": "heracles:item",
-      "item": "croptopia:fried_calamari",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "cf9": {
-      "type": "heracles:item",
-      "item": "croptopia:hashed_brown",
+      "item": "cookingforblockheads:tool_rack",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -234,26 +164,45 @@
       "text": ""
     },
     "description": [
-      "It seems like the unhealthyness of food is directly proportional to it's tastyness"
+      "The multiblock kitchen is a collection of blocks that all serve a function, they should all be connected to each other to allow using all of them",
+      "<br/>",
+      "<br/>",
+      "The cooking table is the heart of your kitchen, it's where you place the cooking books and where you can see what can be made and then make the food",
+      "<br/>",
+      "The sink is a source of water for your recipes",
+      "<br/>",
+      "The kitchen counter is a storage for ingredients, what's inside of them can be used in the cooking table",
+      "<br/>",
+      "The tool rack is used for storing the cooking utensils necessary for many recipes and allowing the cooking table to use them",
+      "<br/>",
+      "The toaster allows to turn bread into toast for free, who would have thought?",
+      "<br/>",
+      "The cow in a jar is a very useful block, it provides milk for recipes and slowly generates infinite milk, to get one you must make a milk jar, make a cow stand on top of it and drop an anvil on it",
+      "<br/>",
+      "The fridge is a storage block that can be made 2 blocks tall, what is unique about it is that it can be upgraded to provide snow and ice and to not use the last item of a kind",
+      "<br/>",
+      "The kitchen floor is the traditional kind of floor found in a kitchen it also allows connecting things in opposite walls in a more subtle way",
+      "<br/>",
+      "The oven is a more efficient and stylish alternative to your old furnace, the oven allows cooking multiple items at once thus being faster and more fuel efficient, the cooking table will also cook things when you chose a recipe there"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          125,
-          200
+          -90,
+          -95
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "croptopia:olive_oil",
+        "id": "cookingforblockheads:cooking_table",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Fried Foods"
+      "translate": "Multiblock Kitchen"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Mussels.json
+++ b/config/heracles/quests/farmeroworlds/Mussels.json
@@ -79,6 +79,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Nether Depths.json
+++ b/config/heracles/quests/farmeroworlds/Nether Depths.json
@@ -41,7 +41,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Nether Depths"
     }

--- a/config/heracles/quests/farmeroworlds/Nether Depths.json
+++ b/config/heracles/quests/farmeroworlds/Nether Depths.json
@@ -1,0 +1,56 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "nd": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "type": "heracles:check"
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Nether Depths adds a whole new world of life to the vast lava oceans of the nether, here you will find many new fish, vegetation and structures, it also adds some other useful things.",
+      "<br/>",
+      "<br/>",
+      "You will also be able to fish in lava now if you have the right fishing rod"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -540,
+          40
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "netherdepthsupgrade:searing_cod",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Nether Depths"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Nether Depths.json
+++ b/config/heracles/quests/farmeroworlds/Nether Depths.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Nether Fizz.json
+++ b/config/heracles/quests/farmeroworlds/Nether Fizz.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Nether Rice Roll Medley.json
+++ b/config/heracles/quests/farmeroworlds/Nether Rice Roll Medley.json
@@ -1,0 +1,57 @@
+{
+  "dependencies": [
+    "Warped Kelp Roll",
+    "Fish Rolls"
+  ],
+  "tasks": {
+    "ndnrrm": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:nether_rice_roll_medley_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "A more aesthetic way to present your sushi"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -580,
+          75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "netherdepthsupgrade:nether_rice_roll_medley_block",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Nether Rice Roll Medley"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Nether Rice Roll Medley.json
+++ b/config/heracles/quests/farmeroworlds/Nether Rice Roll Medley.json
@@ -52,6 +52,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Nether Vinery.json
+++ b/config/heracles/quests/farmeroworlds/Nether Vinery.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Nether Vinery.json
+++ b/config/heracles/quests/farmeroworlds/Nether Vinery.json
@@ -38,7 +38,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Nether Vinery"
     }

--- a/config/heracles/quests/farmeroworlds/Netherite Nectar.json
+++ b/config/heracles/quests/farmeroworlds/Netherite Nectar.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Night Berries.json
+++ b/config/heracles/quests/farmeroworlds/Night Berries.json
@@ -55,6 +55,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Night Berries.json
+++ b/config/heracles/quests/farmeroworlds/Night Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbnb": {
+      "type": "heracles:item",
+      "item": "strangeberries:night_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,30 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found on dark forests",
       "<br/>",
+      "Can only be harvested at night, walking on it during the day gives blindness, breaking it drops nothing",
       "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make night vision potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -253,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:night_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Night Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Noir Wine.json
+++ b/config/heracles/quests/farmeroworlds/Noir Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Normal Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Normal Drinks.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Kettle"
+    "The Keg"
   ],
   "tasks": {
-    "frgtc": {
+    "bcb": {
       "type": "heracles:item",
-      "item": "farmersrespite:green_tea_cookie",
+      "item": "brewinandchewin:beer",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc0": {
+    "bcsa": {
       "type": "heracles:item",
-      "item": "farmersrespite:black_cod",
+      "item": "brewinandchewin:strongroot_ale",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "frtc": {
+    "bcv": {
       "type": "heracles:item",
-      "item": "farmersrespite:tea_curry",
+      "item": "brewinandchewin:vodka",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "frnws": {
+    "bcrw": {
       "type": "heracles:item",
-      "item": "farmersrespite:nether_wart_sourdough",
+      "item": "brewinandchewin:rice_wine",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,37 @@
         "type": "heracles:item"
       }
     },
-    "frbc": {
+    "bck": {
       "type": "heracles:item",
-      "item": "farmersrespite:blazing_chili",
+      "item": "brewinandchewin:kombucha",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bceg": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:egg_grog",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bcm": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:mead",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -80,26 +108,26 @@
       "text": ""
     },
     "description": [
-      "These are some foods made with ingredients used to make the teas and coffee"
+      "A collection of drinks made at a normal temperature"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -650,
-          50
+          -685,
+          -90
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:blazing_chili",
+        "id": "brewinandchewin:beer",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Other Foods"
+      "translate": "Normal Drinks"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Normal Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Normal Drinks.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Other Foods BC.json
+++ b/config/heracles/quests/farmeroworlds/Other Foods BC.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Kettle"
+    "Cheese Making"
   ],
   "tasks": {
-    "frgtc": {
+    "bccp": {
       "type": "heracles:item",
-      "item": "farmersrespite:green_tea_cookie",
+      "item": "brewinandchewin:cheesy_pasta",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc0": {
+    "bcsp": {
       "type": "heracles:item",
-      "item": "farmersrespite:black_cod",
+      "item": "brewinandchewin:scarlet_pierogies",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "frtc": {
+    "bchl": {
       "type": "heracles:item",
-      "item": "farmersrespite:tea_curry",
+      "item": "brewinandchewin:horror_lasagna",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "frnws": {
+    "bcvo": {
       "type": "heracles:item",
-      "item": "farmersrespite:nether_wart_sourdough",
+      "item": "brewinandchewin:vegetable_omelet",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,23 @@
         "type": "heracles:item"
       }
     },
-    "frbc": {
+    "bchcs": {
       "type": "heracles:item",
-      "item": "farmersrespite:blazing_chili",
+      "item": "brewinandchewin:ham_and_cheese_sandwich",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bccos": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:creamy_onion_soup",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -80,26 +94,26 @@
       "text": ""
     },
     "description": [
-      "These are some foods made with ingredients used to make the teas and coffee"
+      "These are the foods that can be made with the 2 types of cheese but can't be placed down"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -650,
-          50
+          -775,
+          30
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:blazing_chili",
+        "id": "brewinandchewin:horror_lasagna",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Other Foods"
+      "translate": "Other Foods BC"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Other Foods BC.json
+++ b/config/heracles/quests/farmeroworlds/Other Foods BC.json
@@ -31,20 +31,6 @@
         "type": "heracles:item"
       }
     },
-    "bchl": {
-      "type": "heracles:item",
-      "item": "brewinandchewin:horror_lasagna",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
     "bcvo": {
       "type": "heracles:item",
       "item": "brewinandchewin:vegetable_omelet",
@@ -76,6 +62,20 @@
     "bccos": {
       "type": "heracles:item",
       "item": "brewinandchewin:creamy_onion_soup",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bchl": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:horror_lasagna",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -121,6 +121,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Other Foods FR.json
+++ b/config/heracles/quests/farmeroworlds/Other Foods FR.json
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Other Foods FR.json
+++ b/config/heracles/quests/farmeroworlds/Other Foods FR.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Kettle"
   ],
   "tasks": {
-    "fdsip": {
+    "frgtc": {
       "type": "heracles:item",
-      "item": "farmersdelight:squid_ink_pasta",
+      "item": "farmersrespite:green_tea_cookie",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "fdts": {
+    "frbc0": {
       "type": "heracles:item",
-      "item": "farmersdelight:tomato_sauce",
+      "item": "farmersrespite:black_cod",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "fdrp": {
+    "frtc": {
       "type": "heracles:item",
-      "item": "farmersdelight:raw_pasta",
+      "item": "farmersrespite:tea_curry",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "fdwd": {
+    "frnws": {
       "type": "heracles:item",
-      "item": "farmersdelight:wheat_dough",
+      "item": "farmersrespite:nether_wart_sourdough",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,51 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "fdpwm": {
+    "frbc": {
       "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_meatballs",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdvn": {
-      "type": "heracles:item",
-      "item": "farmersdelight:vegetable_noodles",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdns": {
-      "type": "heracles:item",
-      "item": "farmersdelight:noodle_soup",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdpwmc": {
-      "type": "heracles:item",
-      "item": "farmersdelight:pasta_with_mutton_chop",
+      "item": "farmersrespite:blazing_chili",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -122,32 +80,26 @@
       "text": ""
     },
     "description": [
-      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
-      "<br/>",
-      "<br/>",
-      "Wheat dough can also be made in multiple ways",
-      "<br/>",
-      "<br/>",
-      "You will also want to make some tomato sauce for the more traditional pasta"
+      "These are some foods made with ingredients used to make the teas and coffee"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -265,
-          50
+          -630,
+          35
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersdelight:raw_pasta",
+        "id": "farmersrespite:blazing_chili",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Pasta"
+      "translate": "Other Foods"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Other Foods.json
+++ b/config/heracles/quests/farmeroworlds/Other Foods.json
@@ -1,0 +1,140 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdfe": {
+      "type": "heracles:item",
+      "item": "farmersdelight:fried_egg",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdsp": {
+      "type": "heracles:item",
+      "item": "farmersdelight:steak_and_potatoes",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:ratatouille",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdgs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:grilled_salmon",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdrmc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:roasted_mutton_chops",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdbbqs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:barbecue_stick",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdbe": {
+      "type": "heracles:item",
+      "item": "farmersdelight:bacon_and_eggs",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "A collection of miscellaneous cooked foods"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -315,
+          100
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:barbecue_stick",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Other Foods"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Other Foods.json
+++ b/config/heracles/quests/farmeroworlds/Other Foods.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Other Sweet Foods.json
+++ b/config/heracles/quests/farmeroworlds/Other Sweet Foods.json
@@ -93,6 +93,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Other Sweet Foods.json
+++ b/config/heracles/quests/farmeroworlds/Other Sweet Foods.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Farmer's Delight"
   ],
   "tasks": {
-    "bcb": {
+    "fdsc": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_box",
+      "item": "farmersdelight:sweet_berry_cookie",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bct": {
+    "fdgc": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_truffle",
+      "item": "farmersdelight:glow_berry_custard",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,23 @@
         "type": "heracles:item"
       }
     },
-    "bcs": {
+    "fdhc": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_jam",
+      "item": "farmersdelight:honey_cookie",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdmp": {
+      "type": "heracles:item",
+      "item": "farmersdelight:melon_popsicle",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +66,26 @@
       "text": ""
     },
     "description": [
-      "Chocolate truffles are quite versatile, they can be eaten, used to cook other things or used to make a chocolate box, the chocolate box can be used as a decoration and you can eat from it by just clicking"
+      "A collection of miscellaneous sweet foods"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -160,
-          -240
+          -340,
+          100
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:chocolate_truffle",
+        "id": "farmersdelight:honey_cookie",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Chocolate Truffle"
+      "translate": "Other Sweet Foods"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Pasta.json
+++ b/config/heracles/quests/farmeroworlds/Pasta.json
@@ -1,0 +1,160 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdsip": {
+      "type": "heracles:item",
+      "item": "farmersdelight:squid_ink_pasta",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdts": {
+      "type": "heracles:item",
+      "item": "farmersdelight:tomato_sauce",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdrp": {
+      "type": "heracles:item",
+      "item": "farmersdelight:raw_pasta",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdwd": {
+      "type": "heracles:item",
+      "item": "farmersdelight:wheat_dough",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdpwm": {
+      "type": "heracles:item",
+      "item": "farmersdelight:pasta_with_meatballs",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdvn": {
+      "type": "heracles:item",
+      "item": "farmersdelight:vegetable_noodles",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdns": {
+      "type": "heracles:item",
+      "item": "farmersdelight:noodle_soup",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdpwmc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:pasta_with_mutton_chop",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "There are many ways to cook pasta, but first you will need the raw pasta, it can be made in many ways but cutting wheat dough with a knife on a cutting board is the most efficient way if you want to save ingredients",
+      "<br/>",
+      "<br/>",
+      "Wheat dough can also be made in multiple ways",
+      "<br/>",
+      "<br/>",
+      "You will also want to make some tomato sauce for the more traditional pasta"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -415,
+          25
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:raw_pasta",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Pasta"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Pasta.json
+++ b/config/heracles/quests/farmeroworlds/Pasta.json
@@ -155,6 +155,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pastries and Baked Goods.json
+++ b/config/heracles/quests/farmeroworlds/Pastries and Baked Goods.json
@@ -247,6 +247,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pet Food.json
+++ b/config/heracles/quests/farmeroworlds/Pet Food.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pet Food.json
+++ b/config/heracles/quests/farmeroworlds/Pet Food.json
@@ -1,0 +1,70 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdhf": {
+      "type": "heracles:item",
+      "item": "farmersdelight:horse_feed",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fddf": {
+      "type": "heracles:item",
+      "item": "farmersdelight:dog_food",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Wolves and horses also get a treat! These foods will give them some helpful effects"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -290,
+          100
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:horse_feed",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Pet Food"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Pies and Cakes.json
+++ b/config/heracles/quests/farmeroworlds/Pies and Cakes.json
@@ -127,8 +127,8 @@
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -415,
-          0
+          -390,
+          50
         ]
       }
     },

--- a/config/heracles/quests/farmeroworlds/Pies and Cakes.json
+++ b/config/heracles/quests/farmeroworlds/Pies and Cakes.json
@@ -149,6 +149,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pies and Cakes.json
+++ b/config/heracles/quests/farmeroworlds/Pies and Cakes.json
@@ -1,0 +1,154 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdsc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:sweet_berry_cheesecake",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cake_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdap": {
+      "type": "heracles:item",
+      "item": "farmersdelight:apple_pie",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcp": {
+      "type": "heracles:item",
+      "item": "farmersdelight:chocolate_pie",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcps": {
+      "type": "heracles:item",
+      "item": "farmersdelight:chocolate_pie_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdscs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:sweet_berry_cheesecake_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdaps": {
+      "type": "heracles:item",
+      "item": "farmersdelight:apple_pie_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdpc": {
+      "type": "heracles:item",
+      "item": "farmersdelight:pie_crust",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "To make pies you will first need a pie crust, pies can be placed and eaten like regular cake or they can be cut in a cutting board with a knife, regular cake can also be cut"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -415,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:chocolate_pie",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Pies and Cakes"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Pies.json
+++ b/config/heracles/quests/farmeroworlds/Pies.json
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pizza.json
+++ b/config/heracles/quests/farmeroworlds/Pizza.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pizza.json
+++ b/config/heracles/quests/farmeroworlds/Pizza.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Cheese Making"
   ],
   "tasks": {
-    "fr": {
+    "bcps": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:pizza_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "bcp": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:pizza",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +38,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "The pizza can be placed down and you will be able to get slices of it without using a knife"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -775,
+          0
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "brewinandchewin:pizza",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Pizza"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Pizzas.json
+++ b/config/heracles/quests/farmeroworlds/Pizzas.json
@@ -124,6 +124,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Popsicles.json
+++ b/config/heracles/quests/farmeroworlds/Popsicles.json
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Popsicles.json
+++ b/config/heracles/quests/farmeroworlds/Popsicles.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Kettle"
+    "Mini Fridge"
   ],
   "tasks": {
-    "frgtc": {
+    "bpcacp": {
       "type": "heracles:item",
-      "item": "farmersrespite:green_tea_cookie",
+      "item": "beachparty:icecream_cactus",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc0": {
+    "bpcp": {
       "type": "heracles:item",
-      "item": "farmersrespite:black_cod",
+      "item": "beachparty:icecream_coconut",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "frtc": {
+    "bpsic": {
       "type": "heracles:item",
-      "item": "farmersrespite:tea_curry",
+      "item": "beachparty:icecream_sweetberries",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -45,9 +45,9 @@
         "type": "heracles:item"
       }
     },
-    "frnws": {
+    "bpcic": {
       "type": "heracles:item",
-      "item": "farmersrespite:nether_wart_sourdough",
+      "item": "beachparty:icecream_chocolate",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -59,9 +59,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc": {
+    "bpmp": {
       "type": "heracles:item",
-      "item": "farmersrespite:blazing_chili",
+      "item": "beachparty:icecream_melon",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -80,26 +80,26 @@
       "text": ""
     },
     "description": [
-      "These are some foods made with ingredients used to make the teas and coffee"
+      "Popsicles and ice cream are made in the mini fridge with ice and a second ingredient"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -650,
-          50
+          70,
+          -380
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:blazing_chili",
+        "id": "beachparty:icecream_coconut",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Other Foods"
+      "translate": "Popsicles and Ice Cream"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Pork Products.json
+++ b/config/heracles/quests/farmeroworlds/Pork Products.json
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Praetorian Wine.json
+++ b/config/heracles/quests/farmeroworlds/Praetorian Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pudding.json
+++ b/config/heracles/quests/farmeroworlds/Pudding.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Pumpkin Cocktail.json
+++ b/config/heracles/quests/farmeroworlds/Pumpkin Cocktail.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Quiche.json
+++ b/config/heracles/quests/farmeroworlds/Quiche.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Quiche.json
+++ b/config/heracles/quests/farmeroworlds/Quiche.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Cheese Making"
   ],
   "tasks": {
-    "fr": {
+    "bcq": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:quiche",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,21 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
+    },
+    "bcqs": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:quiche_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +38,26 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
-      "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "The quiche can be placed down and eaten from there or cut with knife to get 4 slices of it"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -775,
+          -30
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "brewinandchewin:quiche",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Quiche"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Radio.json
+++ b/config/heracles/quests/farmeroworlds/Radio.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Red Jungle Grapes.json
+++ b/config/heracles/quests/farmeroworlds/Red Jungle Grapes.json
@@ -39,6 +39,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Red Savanna Grapes.json
+++ b/config/heracles/quests/farmeroworlds/Red Savanna Grapes.json
@@ -57,6 +57,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Red Taiga Grapes.json
+++ b/config/heracles/quests/farmeroworlds/Red Taiga Grapes.json
@@ -39,6 +39,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Red Wine.json
+++ b/config/heracles/quests/farmeroworlds/Red Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Regeneration Berries.json
+++ b/config/heracles/quests/farmeroworlds/Regeneration Berries.json
@@ -55,6 +55,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Regeneration Berries.json
+++ b/config/heracles/quests/farmeroworlds/Regeneration Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbrb": {
+      "type": "heracles:item",
+      "item": "strangeberries:regeneration_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,30 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found in meadows, flower forests and cherry groves",
       "<br/>",
+      "Must be harvested from fruitful berry bushes, walking on the bush restores health",
       "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make regeneration potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -253,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:regeneration_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Regeneration Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Regular Grapes.json
+++ b/config/heracles/quests/farmeroworlds/Regular Grapes.json
@@ -57,6 +57,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Resistance Berries.json
+++ b/config/heracles/quests/farmeroworlds/Resistance Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbrb": {
+      "type": "heracles:item",
+      "item": "strangeberries:resistance_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found underground on deepslate",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to turn slowness potions into turtle master potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -181,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:resistance_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Resistance Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Resistance Berries.json
+++ b/config/heracles/quests/farmeroworlds/Resistance Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Rice Roll Medley.json
+++ b/config/heracles/quests/farmeroworlds/Rice Roll Medley.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Rice Roll Medley.json
+++ b/config/heracles/quests/farmeroworlds/Rice Roll Medley.json
@@ -1,0 +1,56 @@
+{
+  "dependencies": [
+    "Feasts for a King"
+  ],
+  "tasks": {
+    "fdrrm": {
+      "type": "heracles:item",
+      "item": "farmersdelight:rice_roll_medley_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Unlike the other foods, the rice roll medley doesnt require a bowl, it works more like a decoration, clicking on it will give back the sushi pieces one by one"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -365,
+          -85
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:rice_roll_medley_block",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Rice Roll Medley"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Roast Chicken.json
+++ b/config/heracles/quests/farmeroworlds/Roast Chicken.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Roast Chicken.json
+++ b/config/heracles/quests/farmeroworlds/Roast Chicken.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Feasts for a King"
   ],
   "tasks": {
-    "bcb": {
+    "fdrc": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_box",
+      "item": "farmersdelight:roast_chicken_block",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,23 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bct": {
+    "fdrcb": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_truffle",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "bcs": {
-      "type": "heracles:item",
-      "item": "bakery:chocolate_jam",
+      "item": "farmersdelight:roast_chicken",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +38,26 @@
       "text": ""
     },
     "description": [
-      "Chocolate truffles are quite versatile, they can be eaten, used to cook other things or used to make a chocolate box, the chocolate box can be used as a decoration and you can eat from it by just clicking"
+      "Can fill up to 4 bowls"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -160,
-          -240
+          -465,
+          -85
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:chocolate_truffle",
+        "id": "farmersdelight:roast_chicken_block",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Chocolate Truffle"
+      "translate": "Roast Chicken"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Roasted Veggies and Seeds.json
+++ b/config/heracles/quests/farmeroworlds/Roasted Veggies and Seeds.json
@@ -331,6 +331,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Rotten Berries.json
+++ b/config/heracles/quests/farmeroworlds/Rotten Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Rotten Berries.json
+++ b/config/heracles/quests/farmeroworlds/Rotten Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbrb": {
+      "type": "heracles:item",
+      "item": "strangeberries:rotten_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found on taigas and snowy taigas",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make berry sickness potions or fed to zombies and husks to give them permanent slowness"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -277,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:rotten_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Rotten Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Salads FD.json
+++ b/config/heracles/quests/farmeroworlds/Salads FD.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Farmer's Delight"
   ],
   "tasks": {
-    "bcb": {
+    "fdfs": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_box",
+      "item": "farmersdelight:fruit_salad",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bct": {
+    "fdns": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_truffle",
+      "item": "farmersdelight:nether_salad",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,9 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "bcs": {
+    "fdms": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_jam",
+      "item": "farmersdelight:mixed_salad",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +52,26 @@
       "text": ""
     },
     "description": [
-      "Chocolate truffles are quite versatile, they can be eaten, used to cook other things or used to make a chocolate box, the chocolate box can be used as a decoration and you can eat from it by just clicking"
+      "A few healthy food options"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -160,
-          -240
+          -390,
+          100
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:chocolate_truffle",
+        "id": "farmersdelight:mixed_salad",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Chocolate Truffle"
+      "translate": "Salads FD"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Salads FD.json
+++ b/config/heracles/quests/farmeroworlds/Salads FD.json
@@ -3,6 +3,20 @@
     "Farmer's Delight"
   ],
   "tasks": {
+    "fdms": {
+      "type": "heracles:item",
+      "item": "farmersdelight:mixed_salad",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
     "fdfs": {
       "type": "heracles:item",
       "item": "farmersdelight:fruit_salad",
@@ -20,20 +34,6 @@
     "fdns": {
       "type": "heracles:item",
       "item": "farmersdelight:nether_salad",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "fdms": {
-      "type": "heracles:item",
-      "item": "farmersdelight:mixed_salad",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -71,7 +71,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Salads FD"
+      "translate": "Salads"
     }
   },
   "settings": {
@@ -79,6 +79,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Salads.json
+++ b/config/heracles/quests/farmeroworlds/Salads.json
@@ -121,6 +121,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sandwiches, Hamburgers and More.json
+++ b/config/heracles/quests/farmeroworlds/Sandwiches, Hamburgers and More.json
@@ -127,8 +127,8 @@
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -415,
-          100
+          -390,
+          75
         ]
       }
     },

--- a/config/heracles/quests/farmeroworlds/Sandwiches, Hamburgers and More.json
+++ b/config/heracles/quests/farmeroworlds/Sandwiches, Hamburgers and More.json
@@ -1,0 +1,154 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdbs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:bacon_sandwich",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:chicken_sandwich",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cabbage_rolls",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdes": {
+      "type": "heracles:item",
+      "item": "farmersdelight:egg_sandwich",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdsp": {
+      "type": "heracles:item",
+      "item": "farmersdelight:stuffed_potato",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdmw": {
+      "type": "heracles:item",
+      "item": "farmersdelight:mutton_wrap",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdd": {
+      "type": "heracles:item",
+      "item": "farmersdelight:dumplings",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdh": {
+      "type": "heracles:item",
+      "item": "farmersdelight:hamburger",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "This is a collection of sandwiches, hamburgers and other types of stuffed foods"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -415,
+          100
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:hamburger",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Sandwiches, Hamburgers and More"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Sandwiches, Hamburgers and More.json
+++ b/config/heracles/quests/farmeroworlds/Sandwiches, Hamburgers and More.json
@@ -149,6 +149,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sandwiches.json
+++ b/config/heracles/quests/farmeroworlds/Sandwiches.json
@@ -138,6 +138,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sea Berries.json
+++ b/config/heracles/quests/farmeroworlds/Sea Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sea Berries.json
+++ b/config/heracles/quests/farmeroworlds/Sea Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbsb": {
+      "type": "heracles:item",
+      "item": "strangeberries:sea_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found underwater in oceans, cold oceans, rivers, deep oceans and deep cold oceans",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make water breathing potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -325,
+          209
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:sea_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Sea Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Shepherd's Pie.json
+++ b/config/heracles/quests/farmeroworlds/Shepherd's Pie.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Shepherd's Pie.json
+++ b/config/heracles/quests/farmeroworlds/Shepherd's Pie.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Feasts for a King"
   ],
   "tasks": {
-    "bcb": {
+    "fdsp": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_box",
+      "item": "farmersdelight:shepherds_pie_block",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,23 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bct": {
+    "fdspb": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_truffle",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "bcs": {
-      "type": "heracles:item",
-      "item": "bakery:chocolate_jam",
+      "item": "farmersdelight:shepherds_pie",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +38,26 @@
       "text": ""
     },
     "description": [
-      "Chocolate truffles are quite versatile, they can be eaten, used to cook other things or used to make a chocolate box, the chocolate box can be used as a decoration and you can eat from it by just clicking"
+      "Can fill up to 4 bowls"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -160,
-          -240
+          -390,
+          -85
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:chocolate_truffle",
+        "id": "farmersdelight:shepherds_pie_block",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Chocolate Truffle"
+      "translate": "Shepherd's Pie"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Small Wine Bottle Storage.json
+++ b/config/heracles/quests/farmeroworlds/Small Wine Bottle Storage.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Smoothies.json
+++ b/config/heracles/quests/farmeroworlds/Smoothies.json
@@ -107,6 +107,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Solaris Wine.json
+++ b/config/heracles/quests/farmeroworlds/Solaris Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Soups and Stews FD.json
+++ b/config/heracles/quests/farmeroworlds/Soups and Stews FD.json
@@ -1,0 +1,154 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdbs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:beef_stew",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdbb": {
+      "type": "heracles:item",
+      "item": "farmersdelight:bone_broth",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:chicken_soup",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdvs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:vegetable_soup",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdfs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:fish_stew",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdbcs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:baked_cod_stew",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdns": {
+      "type": "heracles:item",
+      "item": "farmersdelight:noodle_soup",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdps": {
+      "type": "heracles:item",
+      "item": "farmersdelight:pumpkin_soup",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Soups and stews are a variety of highly nourishing foods, always made in a bowl but don't worry you can carry up to 16 of them"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -415,
+          50
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:fish_stew",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Soups and Stews FD"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Soups and Stews FD.json
+++ b/config/heracles/quests/farmeroworlds/Soups and Stews FD.json
@@ -127,8 +127,8 @@
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -415,
-          50
+          -265,
+          75
         ]
       }
     },

--- a/config/heracles/quests/farmeroworlds/Soups and Stews FD.json
+++ b/config/heracles/quests/farmeroworlds/Soups and Stews FD.json
@@ -141,7 +141,7 @@
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Soups and Stews FD"
+      "translate": "Soups and Stews"
     }
   },
   "settings": {
@@ -149,6 +149,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Soups and Stews.json
+++ b/config/heracles/quests/farmeroworlds/Soups and Stews.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Soy Substitutes.json
+++ b/config/heracles/quests/farmeroworlds/Soy Substitutes.json
@@ -96,6 +96,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Speed Berries.json
+++ b/config/heracles/quests/farmeroworlds/Speed Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Speed Berries.json
+++ b/config/heracles/quests/farmeroworlds/Speed Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbsb": {
+      "type": "heracles:item",
+      "item": "strangeberries:speed_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found in birch forests, old growth birch forests and forests",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make a speed potion"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -349,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:speed_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Speed Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Squids.json
+++ b/config/heracles/quests/farmeroworlds/Squids.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Stal Wine.json
+++ b/config/heracles/quests/farmeroworlds/Stal Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Steamed Dragon Leg.json
+++ b/config/heracles/quests/farmeroworlds/Steamed Dragon Leg.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Steamed Dragon Leg.json
+++ b/config/heracles/quests/farmeroworlds/Steamed Dragon Leg.json
@@ -1,0 +1,70 @@
+{
+  "dependencies": [
+    "Big Meals"
+  ],
+  "tasks": {
+    "ededeb": {
+      "type": "heracles:item",
+      "item": "ends_delight:steamed_dragon_egg",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edsde": {
+      "type": "heracles:item",
+      "item": "ends_delight:steamed_dragon_egg_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "It provides 4 bowls of steamed dragon egg, after the egg is empty you can get the half dragon egg shell back"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -590,
+          -160
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:steamed_dragon_egg_block",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Steamed Dragon Leg"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Steamed and Boiled.json
+++ b/config/heracles/quests/farmeroworlds/Steamed and Boiled.json
@@ -177,6 +177,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Strad Wine.json
+++ b/config/heracles/quests/farmeroworlds/Strad Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Strawberry Cake.json
+++ b/config/heracles/quests/farmeroworlds/Strawberry Cake.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Strength Berries.json
+++ b/config/heracles/quests/farmeroworlds/Strength Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbsb": {
+      "type": "heracles:item",
+      "item": "strangeberries:strength_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,28 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found in taigas and snowy taigas",
       "<br/>",
-      "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make strength potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -301,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:strength_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Strength Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Strength Berries.json
+++ b/config/heracles/quests/farmeroworlds/Strength Berries.json
@@ -53,6 +53,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Stuffed Pumpkin.json
+++ b/config/heracles/quests/farmeroworlds/Stuffed Pumpkin.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Stuffed Pumpkin.json
+++ b/config/heracles/quests/farmeroworlds/Stuffed Pumpkin.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Bakery"
+    "Feasts for a King"
   ],
   "tasks": {
-    "bcb": {
+    "fdsp": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_box",
+      "item": "farmersdelight:stuffed_pumpkin_block",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,23 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bct": {
+    "fdspb": {
       "type": "heracles:item",
-      "item": "bakery:chocolate_truffle",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "bcs": {
-      "type": "heracles:item",
-      "item": "bakery:chocolate_jam",
+      "item": "farmersdelight:stuffed_pumpkin",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -52,26 +38,26 @@
       "text": ""
     },
     "description": [
-      "Chocolate truffles are quite versatile, they can be eaten, used to cook other things or used to make a chocolate box, the chocolate box can be used as a decoration and you can eat from it by just clicking"
+      "Can fill up to 4 bowls. must be made in a cooking pot"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -160,
-          -240
+          -440,
+          -85
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "bakery:chocolate_truffle",
+        "id": "farmersdelight:stuffed_pumpkin_block",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Chocolate Truffle"
+      "translate": "Stuffed Pumpkin"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Sun-kissed Wine.json
+++ b/config/heracles/quests/farmeroworlds/Sun-kissed Wine.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sundae.json
+++ b/config/heracles/quests/farmeroworlds/Sundae.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Kettle"
+    "Mini Fridge"
   ],
   "tasks": {
-    "frgtc": {
+    "bpcs": {
       "type": "heracles:item",
-      "item": "farmersrespite:green_tea_cookie",
+      "item": "beachparty:chocolate_icecream",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc0": {
+    "bpss": {
       "type": "heracles:item",
-      "item": "farmersrespite:black_cod",
+      "item": "beachparty:sweetberry_icecream",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,37 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "frtc": {
+    "bpcs0": {
       "type": "heracles:item",
-      "item": "farmersrespite:tea_curry",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "frnws": {
-      "type": "heracles:item",
-      "item": "farmersrespite:nether_wart_sourdough",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "frbc": {
-      "type": "heracles:item",
-      "item": "farmersrespite:blazing_chili",
+      "item": "beachparty:coconut_icecream",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -80,26 +52,26 @@
       "text": ""
     },
     "description": [
-      "These are some foods made with ingredients used to make the teas and coffee"
+      "Sundaes are made in the mini fridge by combining snow and a second ingredient"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -650,
-          50
+          130,
+          -380
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:blazing_chili",
+        "id": "beachparty:chocolate_icecream",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Other Foods"
+      "translate": "Sundae"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Sundae.json
+++ b/config/heracles/quests/farmeroworlds/Sundae.json
@@ -79,6 +79,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sushi and Rice Dishes.json
+++ b/config/heracles/quests/farmeroworlds/Sushi and Rice Dishes.json
@@ -1,0 +1,140 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdcr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cooked_rice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdsr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:salmon_roll",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdkrs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:kelp_roll_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdfr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:fried_rice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdkr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:kelp_roll",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdmr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:mushroom_rice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdcr0": {
+      "type": "heracles:item",
+      "item": "farmersdelight:cod_roll",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Sushi and rice offer a great variety of possibilities in the cooking world and sushi wouldn't be what it is without rice!"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -415,
+          75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:kelp_roll",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Sushi and Rice Dishes"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Sushi and Rice Dishes.json
+++ b/config/heracles/quests/farmeroworlds/Sushi and Rice Dishes.json
@@ -135,6 +135,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sushi.json
+++ b/config/heracles/quests/farmeroworlds/Sushi.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sweet Dough.json
+++ b/config/heracles/quests/farmeroworlds/Sweet Dough.json
@@ -30,7 +30,7 @@
       "Farmer O' Worlds": {
         "position": [
           -75,
-          -220
+          -210
         ]
       }
     },
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sweetberry Cake.json
+++ b/config/heracles/quests/farmeroworlds/Sweetberry Cake.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Sweetberry Cocktail.json
+++ b/config/heracles/quests/farmeroworlds/Sweetberry Cocktail.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Swimming Gear.json
+++ b/config/heracles/quests/farmeroworlds/Swimming Gear.json
@@ -20,9 +20,9 @@
         "type": "heracles:item"
       }
     },
-    "bpbh": {
+    "bpc": {
       "type": "heracles:item",
-      "item": "beachparty:beach_hat",
+      "item": "beachparty:crocs",
       "nbt": {
         "Damage": 0
       },
@@ -37,9 +37,26 @@
         "type": "heracles:item"
       }
     },
-    "bpc": {
+    "bpb": {
       "type": "heracles:item",
-      "item": "beachparty:crocs",
+      "item": "beachparty:bikini",
+      "nbt": {
+        "Damage": 0
+      },
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "bpbh": {
+      "type": "heracles:item",
+      "item": "beachparty:beach_hat",
       "nbt": {
         "Damage": 0
       },
@@ -74,23 +91,6 @@
     "bpsw": {
       "type": "heracles:item",
       "item": "beachparty:swim_wings",
-      "nbt": {
-        "Damage": 0
-      },
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "bpb": {
-      "type": "heracles:item",
-      "item": "beachparty:bikini",
       "nbt": {
         "Damage": 0
       },
@@ -142,6 +142,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/The Big Breakfast.json
+++ b/config/heracles/quests/farmeroworlds/The Big Breakfast.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": false,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/The Fish.json
+++ b/config/heracles/quests/farmeroworlds/The Fish.json
@@ -1,0 +1,218 @@
+{
+  "dependencies": [
+    "Nether Depths"
+  ],
+  "tasks": {
+    "ndg": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:glowdine",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndfg": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:fortress_grouper",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndef": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:eyeball_fish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndss": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:soulsucker",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndsc": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:searing_cod",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndmcf": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:magmacubefish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndwbf": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:wither_bonefish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndbf": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:bonefish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndlp": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:lava_pufferfish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndb": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:blazefish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndof": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:obsidianfish",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "The most important part of our culinary interest is the fish, now we'll learn about everything that can be found in the lava oceans:",
+      "<br/>",
+      "Soul Sucker: Can be found in soul sand valleys, they can be converted into leather for a unique pair of boots",
+      "<br/>",
+      "Wither Bonefish: Can be found in soul sand valleys",
+      "<br/>",
+      "Bonefish: Can be find in nether wastes",
+      "<br/>",
+      "Searing Cod: Can be found in nether wastes",
+      "<br/>",
+      "Glowdine: Can be found in crimson forests",
+      "<br/>",
+      "Lava Pufferfish: Can be found in warped forests and can be used to make a lava vision potion or a wither potion, the chance of either is random",
+      "<br/>",
+      "Obsidianfish: Can be found in basalt deltas",
+      "<br/>",
+      "Magma Cube Fish: Can be found in basalt deltas",
+      "<br/>",
+      "Blazefish: Can be found in a new under lava structure, the fortress piece",
+      "<br/>",
+      "Fortress Grouper: Can be found in crimson forests, when combined with shears it will give plates for making lava glass, when eaten gives absorption",
+      "<br/>",
+      "Eyeball Fish: Can be found in crimson forests, when combined with shears it gives eyeball fish eyes used for making lava glass, when eaten gives night vision, can be used to make lava sight potions"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -540,
+          75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "netherdepthsupgrade:lava_pufferfish",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "The Fish"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/The Fish.json
+++ b/config/heracles/quests/farmeroworlds/The Fish.json
@@ -213,6 +213,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/The Keg.json
+++ b/config/heracles/quests/farmeroworlds/The Keg.json
@@ -1,0 +1,68 @@
+{
+  "dependencies": [
+    "Brewin' and Chewin'"
+  ],
+  "tasks": {
+    "bck": {
+      "type": "heracles:item",
+      "item": "brewinandchewin:keg",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "The keg is where you will ferment all the new drinks and some foods, the keg has 5 temperatures, every recipe will require a specific one",
+      "<br/>",
+      "<br/>",
+      "/7/Normal/7/ is the default temperature when the keg is placed with nothing surrounding it",
+      "<br/>",
+      "<br/>",
+      "/6/Warm/6/ is achieved by placing hot blocks like magma blocks or lava around the keg in a 3x3x3 area with the keg being the center of the cube, /c/Hot/c/ is achieved by adding even more blocks around the keg",
+      "<br/>",
+      "<br/>",
+      "/b/Cold/b/ is achieved by placing cold blocks like snow or any kind of ice around the keg in a 3x3x3 area with the keg being the center of the cube, /1/Frigid/1/ is achieved by adding even more blocks around the keg",
+      "<br/>",
+      "<br/>",
+      "Biome temperature won't change the temperature of the keg but it will change how many blocks are needed to change the temperature, for example if you are in a desert you will need fewer hot blocks to make it warm but you will need more cold blocks to make it cold"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -685,
+          -15
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "brewinandchewin:keg",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "The Keg"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/The Keg.json
+++ b/config/heracles/quests/farmeroworlds/The Keg.json
@@ -63,6 +63,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Tiki Bar.json
+++ b/config/heracles/quests/farmeroworlds/Tiki Bar.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Toast.json
+++ b/config/heracles/quests/farmeroworlds/Toast.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Toasts.json
+++ b/config/heracles/quests/farmeroworlds/Toasts.json
@@ -121,6 +121,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Tools of a Chef.json
+++ b/config/heracles/quests/farmeroworlds/Tools of a Chef.json
@@ -93,6 +93,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Trees.json
+++ b/config/heracles/quests/farmeroworlds/Trees.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Utilities FD.json
+++ b/config/heracles/quests/farmeroworlds/Utilities FD.json
@@ -90,6 +90,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Utilities FD.json
+++ b/config/heracles/quests/farmeroworlds/Utilities FD.json
@@ -69,7 +69,7 @@
       "Farmer O' Worlds": {
         "position": [
           -295,
-          -35
+          -40
         ]
       }
     },

--- a/config/heracles/quests/farmeroworlds/Utilities FD.json
+++ b/config/heracles/quests/farmeroworlds/Utilities FD.json
@@ -1,0 +1,95 @@
+{
+  "dependencies": [
+    "Farmer's Delight"
+  ],
+  "tasks": {
+    "fdrs": {
+      "type": "heracles:item",
+      "item": "farmersdelight:rich_soil",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdr": {
+      "type": "heracles:item",
+      "item": "farmersdelight:rope",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "fdsn": {
+      "type": "heracles:item",
+      "item": "farmersdelight:safety_net",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "Farmer's Delight also adds a few optional utilities",
+      "<br/>",
+      "<br/>",
+      "Rich soil, a very useful block, it can be made into farmland that speeds up crop growth, to obtain rich soil you must first craft organic compost, then it must be placed in the world for it to slowly decompose into rich soil, having sunlight, water and decomposers like more rich soil and mushrooms touching the organic compost will speed up the process.",
+      "Rich soil also has another unique property, it allows planting mushrooms on it which will grow regardless of light into mushroom colonies.",
+      "These colonies can be obtained with shears to serve as decorations or can be sheared to obtain extra mushrooms for your cooking, breaking the colony will also give mushrooms but it will take longer for it to grow than simply shearing it",
+      "<br/>",
+      "<br/>",
+      "Rope works as a ladder that needs no other block, it can be used as a way to get into a treehouse or floating base without building an ugly pillar, it also has another functionality, placing ropes above a tomato allows the tomato to climb into the rope, there is no height limit to this so you can have the tallest tomato shrub ever seen!",
+      "<br/>",
+      "<br/>",
+      "The safety net is better looking alternative to water or slime blocks for stopping falls, they negate fall damage and make you bounce a bit, holding shift will make you take damage but not bounce"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -295,
+          -35
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "farmersdelight:rich_soil_farmland",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Utilities"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Utilities.json
+++ b/config/heracles/quests/farmeroworlds/Utilities.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Vegetarian Recipes.json
+++ b/config/heracles/quests/farmeroworlds/Vegetarian Recipes.json
@@ -180,6 +180,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Vegetarian Recipes.json
+++ b/config/heracles/quests/farmeroworlds/Vegetarian Recipes.json
@@ -1,0 +1,185 @@
+{
+  "dependencies": [
+    "Crops and Plants"
+  ],
+  "tasks": {
+    "edcfp": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_flower_pie",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edcc": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_cookie",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edes": {
+      "type": "heracles:item",
+      "item": "ends_delight:ender_sauce",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edems": {
+      "type": "heracles:item",
+      "item": "ends_delight:end_mixed_salad",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "eddbcs": {
+      "type": "heracles:item",
+      "item": "ends_delight:dragon_breath_and_chorus_soup",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edcfp1": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_fruit_pie",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edsrc": {
+      "type": "heracles:item",
+      "item": "ends_delight:stuffed_rice_cake",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edcfp0": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_fruit_popsicle",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edcfps": {
+      "type": "heracles:item",
+      "item": "ends_delight:chorus_fruit_pie_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "edas": {
+      "type": "heracles:item",
+      "item": "ends_delight:assorted_salad",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "This are recipes made mostly from chorus succulents and grains without using any of the meats",
+      "<br/>",
+      "<br/>",
+      "The chorus fruit pie can be placed and eaten from there or be cut on a cutting board"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -610,
+          -75
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "ends_delight:chorus_flower_pie",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Vegetarian Recipes"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/Vinery.json
+++ b/config/heracles/quests/farmeroworlds/Vinery.json
@@ -48,6 +48,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Vinery.json
+++ b/config/heracles/quests/farmeroworlds/Vinery.json
@@ -38,7 +38,7 @@
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
     "title": {
       "translate": "Vinery"
     }

--- a/config/heracles/quests/farmeroworlds/Waffles.json
+++ b/config/heracles/quests/farmeroworlds/Waffles.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Warm Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Warm Drinks.json
@@ -1,11 +1,11 @@
 {
   "dependencies": [
-    "Kettle"
+    "The Keg"
   ],
   "tasks": {
-    "frgtc": {
+    "bcpj": {
       "type": "heracles:item",
-      "item": "farmersrespite:green_tea_cookie",
+      "item": "brewinandchewin:pale_jane",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "frbc0": {
+    "bcbm": {
       "type": "heracles:item",
-      "item": "farmersrespite:black_cod",
+      "item": "brewinandchewin:bloody_mary",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -31,37 +31,9 @@
         "type": "heracles:item"
       }
     },
-    "frtc": {
+    "bcsr": {
       "type": "heracles:item",
-      "item": "farmersrespite:tea_curry",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "frnws": {
-      "type": "heracles:item",
-      "item": "farmersrespite:nether_wart_sourdough",
-      "amount": 1,
-      "collection": "AUTOMATIC",
-      "title": "",
-      "icon": {
-        "item": {
-          "id": "minecraft:air",
-          "count": 0
-        },
-        "type": "heracles:item"
-      }
-    },
-    "frbc": {
-      "type": "heracles:item",
-      "item": "farmersrespite:blazing_chili",
+      "item": "brewinandchewin:saccharine_rum",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -80,26 +52,26 @@
       "text": ""
     },
     "description": [
-      "These are some foods made with ingredients used to make the teas and coffee"
+      "A collection of drinks made with a warm keg"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -650,
-          50
+          -660,
+          -90
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:blazing_chili",
+        "id": "brewinandchewin:saccharine_rum",
         "count": 1
       },
       "type": "heracles:item"
     },
     "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Other Foods"
+      "translate": "Warm Drinks"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Warm Drinks.json
+++ b/config/heracles/quests/farmeroworlds/Warm Drinks.json
@@ -3,9 +3,9 @@
     "The Keg"
   ],
   "tasks": {
-    "bcpj": {
+    "bcbm": {
       "type": "heracles:item",
-      "item": "brewinandchewin:pale_jane",
+      "item": "brewinandchewin:bloody_mary",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -17,9 +17,9 @@
         "type": "heracles:item"
       }
     },
-    "bcbm": {
+    "bcpj": {
       "type": "heracles:item",
-      "item": "brewinandchewin:bloody_mary",
+      "item": "brewinandchewin:pale_jane",
       "amount": 1,
       "collection": "AUTOMATIC",
       "title": "",
@@ -79,6 +79,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Warped Fire Berries.json
+++ b/config/heracles/quests/farmeroworlds/Warped Fire Berries.json
@@ -55,6 +55,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Warped Fire Berries.json
+++ b/config/heracles/quests/farmeroworlds/Warped Fire Berries.json
@@ -1,9 +1,13 @@
 {
   "dependencies": [
-    "Farmer's Delight"
+    "Berries Assemble"
   ],
   "tasks": {
-    "fr": {
+    "sbwfb": {
+      "type": "heracles:item",
+      "item": "strangeberries:warped_fire_berries",
+      "amount": 1,
+      "collection": "AUTOMATIC",
       "title": "",
       "icon": {
         "item": {
@@ -11,8 +15,7 @@
           "count": 0
         },
         "type": "heracles:item"
-      },
-      "type": "heracles:check"
+      }
     }
   },
   "rewards": {},
@@ -21,29 +24,30 @@
       "text": ""
     },
     "description": [
-      "Farmer's Respite is all about tea time, you'll be able to make multiples types of tea and a few treats to eat alongside it",
+      "Found on warped forests and on netherrack",
       "<br/>",
+      "Careful harvesting the bush has a high chance of teleporting you nearby, breaking it drops nothing",
       "<br/>",
-      "This mod also has great Create compatibility so you can make your very own tea and cake assembling facility"
+      "Can be used to make fire resistance potions"
     ],
     "groups": {
       "Farmer O' Worlds": {
         "position": [
-          -640,
-          15
+          -205,
+          185
         ]
       }
     },
     "icon": {
       "item": {
-        "id": "farmersrespite:yellow_tea",
+        "id": "strangeberries:warped_fire_berries",
         "count": 1
       },
       "type": "heracles:item"
     },
-    "icon_background": "heracles:textures/gui/quest_backgrounds/circles.png",
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
     "title": {
-      "translate": "Farmer's Respite"
+      "translate": "Warped Fire Berries"
     }
   },
   "settings": {

--- a/config/heracles/quests/farmeroworlds/Warped Grape.json
+++ b/config/heracles/quests/farmeroworlds/Warped Grape.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Warped Kelp Roll.json
+++ b/config/heracles/quests/farmeroworlds/Warped Kelp Roll.json
@@ -65,6 +65,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Warped Kelp Roll.json
+++ b/config/heracles/quests/farmeroworlds/Warped Kelp Roll.json
@@ -1,0 +1,70 @@
+{
+  "dependencies": [
+    "Nether Depths"
+  ],
+  "tasks": {
+    "ndwkr": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:warped_kelp_roll",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "ndwkrs": {
+      "type": "heracles:item",
+      "item": "netherdepthsupgrade:warped_kelp_roll_slice",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {},
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "A vegetarian alternative to fish rolls, it's made with warped kelp which can be found in the lava oceans of the nether, it can be cut into slices on a cutting board"
+    ],
+    "groups": {
+      "Farmer O' Worlds": {
+        "position": [
+          -580,
+          40
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "netherdepthsupgrade:warped_kelp_roll",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Warped Kelp Roll"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/farmeroworlds/White Grapes.json
+++ b/config/heracles/quests/farmeroworlds/White Grapes.json
@@ -57,6 +57,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/White Jungle Grapes.json
+++ b/config/heracles/quests/farmeroworlds/White Jungle Grapes.json
@@ -39,6 +39,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/White Savanna Grapes.json
+++ b/config/heracles/quests/farmeroworlds/White Savanna Grapes.json
@@ -57,6 +57,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/White Taiga Grapes.json
+++ b/config/heracles/quests/farmeroworlds/White Taiga Grapes.json
@@ -54,6 +54,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Wine Box.json
+++ b/config/heracles/quests/farmeroworlds/Wine Box.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Wine Rack.json
+++ b/config/heracles/quests/farmeroworlds/Wine Rack.json
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Wine ageing.json
+++ b/config/heracles/quests/farmeroworlds/Wine ageing.json
@@ -37,6 +37,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Winemaker Armor.json
+++ b/config/heracles/quests/farmeroworlds/Winemaker Armor.json
@@ -108,6 +108,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }

--- a/config/heracles/quests/farmeroworlds/Yeast.json
+++ b/config/heracles/quests/farmeroworlds/Yeast.json
@@ -30,7 +30,7 @@
       "Farmer O' Worlds": {
         "position": [
           -105,
-          -250
+          -240
         ]
       }
     },
@@ -51,6 +51,6 @@
     "showDependencyArrow": true,
     "repeatable": false,
     "individual_progress": false,
-    "hidden": "LOCKED"
+    "hidden": "IN_PROGRESS"
   }
 }


### PR DESCRIPTION
Added quests for Farmer's Delight, Farmer's Respite, Nether Depths Upgrade, End's Delight, Brewin' and Chewin', Fright's Delight and Strange Berries
Updated Croptopia crop list to add unified FD crops
Updated Beachparty Quests with a more compact design and removed pelicans because of the recent update deleting them
Updated some quest icons to show where each mod's quests start