### PR TITLE
fix: bank quests description

### DIFF
--- a/config/heracles/quests/storage/bank_1.json
+++ b/config/heracles/quests/storage/bank_1.json
@@ -53,7 +53,7 @@
       "</column>",
       "</columns>",
       "<br/>",
-      "   The start of something powerful. The start of something so mind boggling extreme, it's hard to believe. This is the Bank 1. It's created with a single barrel, then surrounding it with 9 coal blocks, equaling about 13,500 kilograms.",
+      "   The start of something powerful. The start of something so mind boggling extreme, it's hard to believe. This is the Bank 1. It's created with a single barrel, then surrounding it with 8 coal blocks, equaling about 13,500 kilograms.",
       "<br/>",
       "   These \"Banks\" are practically pocket dimensions where you can store your goodies. This first one holds 9 different types of items, but a whopping 256 of each item in each of the 9 slots. This is just the beginning!",
       "<br/>",

--- a/config/heracles/quests/storage/bank_2.json
+++ b/config/heracles/quests/storage/bank_2.json
@@ -53,7 +53,7 @@
       "</column>",
       "</columns>",
       "<br/>",
-      "  The Bank 2, made by taking your previous one and surrounding it by 9 blocks of copper—about 80,100 kilograms worth.",
+      "  The Bank 2, made by taking your previous one and surrounding it by 8 blocks of copper—about 80,100 kilograms worth.",
       "<br/>",
       "  This brings your total storage to 18 different slots with each slot holding up to 1,024 items in each.",
       "<br/>",

--- a/config/heracles/quests/storage/bank_3.json
+++ b/config/heracles/quests/storage/bank_3.json
@@ -53,7 +53,7 @@
       "</column>",
       "</columns>",
       "<br/>",
-      "  The Bank 3, made by taking your previous one and surrounding it by 9 blocks of iron (~70,857 kg).",
+      "  The Bank 3, made by taking your previous one and surrounding it by 8 blocks of iron (~70,857 kg).",
       "<br/>",
       "  This brings your total storage to 27 different slots with each slot holding up to 4,096 items in each.",
       "<br/>",

--- a/config/heracles/quests/storage/bank_4.json
+++ b/config/heracles/quests/storage/bank_4.json
@@ -53,7 +53,7 @@
       "</column>",
       "</columns>",
       "<br/>",
-      "   The Bank 4, made by taking your previous one and surrounding it by 9 blocks of gold (~173,880 kg).",
+      "   The Bank 4, made by taking your previous one and surrounding it by 8 blocks of gold (~173,880 kg).",
       "<br/>",
       "  This brings your total storage to 36 different slots with each slot holding up to 16,384 items in each.",
       "<br/>",

--- a/config/heracles/quests/storage/bank_5.json
+++ b/config/heracles/quests/storage/bank_5.json
@@ -53,7 +53,7 @@
       "</column>",
       "</columns>",
       "<br/>",
-      "   The Bank 5, made by taking your previous one and surrounding it by 9 blocks of emerald (~24,660 kg).",
+      "   The Bank 5, made by taking your previous one and surrounding it by 8 blocks of emerald (~24,660 kg).",
       "<br/>",
       "  This brings your total storage to 54 different slots with each slot holding up to 65,536 items in each.",
       "<br/>",

--- a/config/heracles/quests/storage/bank_6.json
+++ b/config/heracles/quests/storage/bank_6.json
@@ -53,7 +53,7 @@
       "</column>",
       "</columns>",
       "<br/>",
-      "   The Bank 6, made by taking your previous one and surrounding it by 9 blocks of diamond (~31,590 kg).",
+      "   The Bank 6, made by taking your previous one and surrounding it by 8 blocks of diamond (~31,590 kg).",
       "<br/>",
       "  This brings your total storage to 81 different slots with each slot holding up to 262,144 items in each.",
       "<br/>",

--- a/config/heracles/quests/storage/bank_7.json
+++ b/config/heracles/quests/storage/bank_7.json
@@ -53,7 +53,7 @@
       "</column>",
       "</columns>",
       "<br/>",
-      "   The Bank 7, made by taking your previous one and surrounding it by 9 blocks of netherite (~1,467,130.5 kg).",
+      "   The Bank 7, made by taking your previous one and surrounding it by 8 blocks of netherite (~1,467,130.5 kg).",
       "<br/>",
       "  This brings your total storage to 108 different slots with each slot holding up to 1,000,000,000 items in each.",
       "<br/>",


### PR DESCRIPTION
Fixed descriptions of bank quests, indicating the wrong number of blocks surrounding the central item.