### PR TITLE
Indrev quests

### DIFF
--- a/config/heracles/quests/industrialrevolution/Charging the Core.json
+++ b/config/heracles/quests/industrialrevolution/Charging the Core.json
@@ -1,0 +1,133 @@
+{
+  "dependencies": [
+    "Modular Workbench MK4"
+  ],
+  "tasks": {
+    "14DD0067D573465C": {
+      "type": "heracles:item",
+      "item": "indrev:laser_emitter_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "4496671EA77E9495": {
+      "type": "heracles:item",
+      "item": "indrev:capsule",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "70BE041B9B65C2DF": {
+      "type": "heracles:item",
+      "item": "indrev:modular_core",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "789B8EBA44137D09": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:modular_core",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "The base for every modular tool."
+    },
+    "description": [
+      "<h2>The base for every modular tool.</h2>",
+      "<hr/>",
+      "<task task=\"14DD0067D573465C\" quest=\"Charging the Core\"/>",
+      "<task task=\"4496671EA77E9495\" quest=\"Charging the Core\"/>",
+      "<task task=\"70BE041B9B65C2DF\" quest=\"Charging the Core\"/>",
+      "<hr/>",
+      "To activate it, you'll need at least one Laser, one Capsule and a lot of stored energy (100M).",
+      "<br/>",
+      "The Capsule will hold your Core of Modularity during the process of activation.",
+      "<br/>",
+      "It will emit a redstone signal when it's finished.",
+      "<br/>",
+      "Laser Emitters should be placed facing the capsule with AN EXACT 3 BLOCKS OF AIR BETWEEN LASER AND CAPSULE. They store up to 2,5M LF and require a redstone signal to be toggled on.",
+      "For security have some way to turn off the redstone signal from afar.",
+      "<br/>",
+      "This process takes time but it goes faster for each laser emitter active.",
+      "<br/>",
+      "You must pay attention to these details to avoid problems:",
+      "<br/>",
+      "- Pointing the laser emitter to something other than the capsule or and empty capsule will result in an explosion.",
+      "<br/>",
+      "- If the laser emitters run out of power during the process, all progress will be lost.",
+      "<br/>",
+      "- Make sure to turn off your laser emitters before retrieving the activated core otherwise it will blow up.",
+      "<br/>",
+      "- Do not leave the world or the chunks while the lasers are active, it will make them explode, turn them off before leaving.",
+      "<hr/>",
+      "<reward reward=\"789B8EBA44137D09\" quest=\"Charging the Core\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          96,
+          -48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:laser_emitter_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Charging the Core of Modularity"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Circuit MK1.json
+++ b/config/heracles/quests/industrialrevolution/Circuit MK1.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "Nikolite Dust"
+  ],
+  "tasks": {
+    "7D53A62DB0D746E1": {
+      "type": "heracles:item",
+      "item": "indrev:circuit_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "238F5DC73A868F07": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:circuit_mk1",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "First near quantum level computer circuits"
+    },
+    "description": [
+      "<h2>First near quantum level computer circuits</h2>",
+      "<hr/>",
+      "<task task=\"7D53A62DB0D746E1\" quest=\"Circuit MK1\"/>",
+      "<hr/>",
+      "One of the basic components for MK1 machines.",
+      "<hr/>",
+      "<reward reward=\"238F5DC73A868F07\" quest=\"Circuit MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -160,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:circuit_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "MK1 Circuit"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Circuit MK2.json
+++ b/config/heracles/quests/industrialrevolution/Circuit MK2.json
@@ -1,0 +1,85 @@
+{
+  "dependencies": [
+    "Circuit MK1",
+    "Nikolite Ingot"
+  ],
+  "tasks": {
+    "55EB225CEDCC8BB0": {
+      "type": "heracles:item",
+      "item": "indrev:circuit_mk2",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "25DAAEA3159EC8A7": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:nikolite_ingot",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "This helped indrev start their campaign for revolution."
+    },
+    "description": [
+      "<h2>This helped indrev start their campaign for revolution.</h2>",
+      "<hr/>",
+      "<task task=\"55EB225CEDCC8BB0\" quest=\"Circuit MK2\"/>",
+      "<hr/>",
+      "Mainly used for MK2 upgrades.",
+      "<hr/>",
+      "<reward reward=\"25DAAEA3159EC8A7\" quest=\"Circuit MK2\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -96,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:circuit_mk2",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "MK2 Circuit"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Circuit MK3.json
+++ b/config/heracles/quests/industrialrevolution/Circuit MK3.json
@@ -1,0 +1,85 @@
+{
+  "dependencies": [
+    "Enriched Nikolite Dust",
+    "Circuit MK2"
+  ],
+  "tasks": {
+    "153F8D1FE2667FE0": {
+      "type": "heracles:item",
+      "item": "indrev:circuit_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "77E243FC4207E72E": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:enriched_nikolite_dust",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Just when you thought it couldn't get better."
+    },
+    "description": [
+      "<h2>Just when you thought it couldn't get better.</h2>",
+      "<hr/>",
+      "<task task=\"153F8D1FE2667FE0\" quest=\"Circuit MK3\"/>",
+      "<hr/>",
+      "Mainly used for MK3 upgrades.",
+      "<hr/>",
+      "<reward reward=\"77E243FC4207E72E\" quest=\"Circuit MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -32,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:circuit_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "MK3 Circuit"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Circuit MK4.json
+++ b/config/heracles/quests/industrialrevolution/Circuit MK4.json
@@ -1,0 +1,85 @@
+{
+  "dependencies": [
+    "Circuit MK3",
+    "Enriched Nikolite Ingot"
+  ],
+  "tasks": {
+    "6C45B817876223D3": {
+      "type": "heracles:item",
+      "item": "indrev:circuit_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "52BF8DAAFC8EC7A0": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:enriched_nikolite_ingot",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Circuit go brrrrrr"
+    },
+    "description": [
+      "<h2>Circuit go brrrrrr</h2>",
+      "<hr/>",
+      "<task task=\"6C45B817876223D3\" quest=\"Circuit MK4\"/>",
+      "<hr/>",
+      "The best circuit to ever be created, you'll need it for the really good equipment.",
+      "<hr/>",
+      "<reward reward=\"52BF8DAAFC8EC7A0\" quest=\"Circuit MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          32,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:circuit_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "MK4 Circuit"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Complete IndRev.json
+++ b/config/heracles/quests/industrialrevolution/Complete IndRev.json
@@ -1,0 +1,146 @@
+{
+  "dependencies": [
+    "Modular Chestplate",
+    "Modular Helmet",
+    "IR Battery",
+    "IR Charge Pad MK4",
+    "Nikolite Ingot",
+    "IR Enhancers",
+    "IR Factory Components",
+    "IR Electric Furnace Factory MK4",
+    "Modular Workbench MK4",
+    "IR Ore Multiplication",
+    "Wither Proof Obsidian",
+    "IR Item Pipe MK2",
+    "Poor Mans Compressor",
+    "IR Item Pipe MK3",
+    "Modular Boots",
+    "IR Item Pipe MK4",
+    "IR Heat Gen MK4",
+    "IR Item Pipe MK1",
+    "Circuit MK1",
+    "Circuit MK2",
+    "Circuit MK3",
+    "Circuit MK4",
+    "Welcome to the Revolution",
+    "IR Farming",
+    "IR Servos",
+    "IR Solid Infuser MK1",
+    "Modular Leggings",
+    "IR Energy Reader",
+    "IR Fluid Infuser MK1",
+    "IR Drain and Pump MK1",
+    "Steel Plate from IR",
+    "IR Biomass Gen MK3",
+    "IR Pulverizer Factory MK4",
+    "IR Solid Infuser Factory MK4",
+    "IR Cable MK4",
+    "IR Cable MK3",
+    "IR Compressor MK1",
+    "IR Cable MK2",
+    "IR Compressor Factory MK4",
+    "IR Cable MK1",
+    "IR Fluid Pipe MK1",
+    "IR Fluid Pipe MK2",
+    "IR Machine Block",
+    "Modular Mining Drill",
+    "Enriched Nikolite Ingot",
+    "Configurability",
+    "IR Fluid Pipe MK3",
+    "IR Fluid Pipe MK4",
+    "IR Drill Bottom",
+    "IR needs only the best diamonds",
+    "IR Pulverizer MK1",
+    "IR Coal Gen MK1",
+    "Charging the Core",
+    "Nikolite Dust",
+    "IR Recycler MK2",
+    "IR Empty Enhancer",
+    "Enriched Nikolite Dust",
+    "Modular Core Activated",
+    "IR Fisher MK4",
+    "Gamer Axe",
+    "IR Fisher MK3",
+    "IR Fisher MK2",
+    "IR Sawmill MK1",
+    "IR Solar Gen MK3",
+    "IR Solar Gen MK1",
+    "IR Tier Upgrade MK2",
+    "IR Tier Upgrade MK4",
+    "IR Tier Upgrade MK3"
+  ],
+  "tasks": {
+    "28FBE0DAB8D6BF8F": {
+      "title": "&bIndustrial Revolution 100%",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "type": "heracles:check"
+    }
+  },
+  "rewards": {
+    "47349A13BACC591D": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "trofers:medium_pillar",
+        "count": 1,
+        "nbt": {
+          "BlockEntityTag": {
+            "Trophy": "trofers:indrev"
+          }
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Complete all quests to obtain the trophy!"
+    },
+    "description": [
+      "<h2>Complete all quests to obtain the trophy!</h2>",
+      "<hr/>",
+      "<task task=\"28FBE0DAB8D6BF8F\" quest=\"Complete IndRev\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"47349A13BACC591D\" quest=\"Complete IndRev\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -128,
+          -320
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "trofers:medium_pillar",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/gears.png",
+    "title": {
+      "translate": "Industrial Revolution 100%"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": false,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Configurability.json
+++ b/config/heracles/quests/industrialrevolution/Configurability.json
@@ -1,0 +1,101 @@
+{
+  "dependencies": [
+    "Welcome to the Revolution"
+  ],
+  "tasks": {
+    "120ED12697D4981E": {
+      "type": "heracles:item",
+      "item": "indrev:wrench",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "6476760A6188EB18": {
+      "type": "heracles:item",
+      "item": "indrev:screwdriver",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "7B3AA028EB162EEF": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:tin_ingot",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Quit screwing around and wrench it off"
+    },
+    "description": [
+      "<h2>Quit screwing around and wrench it off</h2>",
+      "<hr/>",
+      "<task task=\"120ED12697D4981E\" quest=\"Configurability\"/>",
+      "<task task=\"6476760A6188EB18\" quest=\"Configurability\"/>",
+      "<hr/>",
+      "The Wrench can be used to rotate blocks and break machines while keeping their energy when using it while crouching.",
+      "<br/>",
+      "The Screwdriver is used to configure machines' inputs and outputs for items and fluids. It can also be used on Lazuli Flux Containers to configurate energy sides.",
+      "<hr/>",
+      "<reward reward=\"7B3AA028EB162EEF\" quest=\"Configurability\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -304,
+          -240
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "minecraft:map",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Configurability"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Enriched Nikolite Dust.json
+++ b/config/heracles/quests/industrialrevolution/Enriched Nikolite Dust.json
@@ -1,0 +1,83 @@
+{
+  "dependencies": [
+    "IR needs only the best diamonds",
+    "Nikolite Ingot"
+  ],
+  "tasks": {
+    "0C2E5913E46CCEE9": {
+      "type": "heracles:item",
+      "item": "indrev:enriched_nikolite_dust",
+      "amount": 4,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "70FE93467EB59E75": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:enriched_nikolite_dust",
+        "count": 2,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"0C2E5913E46CCEE9\" quest=\"Enriched Nikolite Dust\"/>",
+      "<hr/>",
+      "A more advanced form of nikolite, MK3 upgrades will now be available to you.",
+      "<hr/>",
+      "<reward reward=\"70FE93467EB59E75\" quest=\"Enriched Nikolite Dust\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -32,
+          48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:enriched_nikolite_dust",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Enriched Nikolite Dust"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Enriched Nikolite Ingot.json
+++ b/config/heracles/quests/industrialrevolution/Enriched Nikolite Ingot.json
@@ -1,0 +1,82 @@
+{
+  "dependencies": [
+    "Enriched Nikolite Dust"
+  ],
+  "tasks": {
+    "Enriched Nikolite Ingot": {
+      "type": "heracles:item",
+      "item": "indrev:enriched_nikolite_ingot",
+      "amount": 4,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "2F78EABB9CDE6439": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:enriched_nikolite_ingot",
+        "count": 2,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"Enriched Nikolite Ingot\" quest=\"Enriched Nikolite Ingot\"/>",
+      "<hr/>",
+      "The pinnacle of nikolite refinement, the best machinery can be made with this.",
+      "<hr/>",
+      "<reward reward=\"2F78EABB9CDE6439\" quest=\"Enriched Nikolite Ingot\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          32,
+          16
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:enriched_nikolite_ingot",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Enriched Nikolite Ingot"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Gamer Axe.json
+++ b/config/heracles/quests/industrialrevolution/Gamer Axe.json
@@ -1,0 +1,86 @@
+{
+  "dependencies": [
+    "Modular Core Activated"
+  ],
+  "tasks": {
+    "indrev_gamer_axe": {
+      "type": "heracles:item",
+      "item": "indrev:gamer_axe",
+      "nbt": {
+        "Damage": 0
+      },
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "indrev_gamer_axe_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:module_sharpness",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_gamer_axe\" quest=\"Gamer Axe\"/>",
+      "<hr/>",
+      "The gamer axe is a powerful and fast swinging weapon and tool, it can be used both as an axe and as a weapon, to be used as a weapon you must go to controls and make a keybind to turn on the gamer axe, while the axe is active it will quickly drain energy but have a lot of damage.",
+      "<hr/>",
+      "<reward reward=\"indrev_gamer_axe_reward\" quest=\"Gamer Axe\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          216,
+          48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:gamer_axe",
+        "count": 1,
+        "nbt": {
+          "Active": 1,
+          "Progress": 1,
+          "Damage": 0,
+          "selected": {},
+          "energy": 9185
+        }
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Gamer Axe"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Battery.json
+++ b/config/heracles/quests/industrialrevolution/IR Battery.json
@@ -1,0 +1,82 @@
+{
+  "dependencies": [
+    "Poor Mans Compressor"
+  ],
+  "tasks": {
+    "0FFED7DEC1728D8A": {
+      "type": "heracles:item",
+      "item": "indrev:battery",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "1ECC3DF4AADC805D": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:battery",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"0FFED7DEC1728D8A\" quest=\"IR Battery\"/>",
+      "<hr/>",
+      "The battery is an essential crafting component but it can also be used as a portable energy storage device.",
+      "<hr/>",
+      "<reward reward=\"1ECC3DF4AADC805D\" quest=\"IR Battery\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -256,
+          -48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:battery",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Battery"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Biomass Gen MK3.json
+++ b/config/heracles/quests/industrialrevolution/IR Biomass Gen MK3.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Recycler MK2"
+  ],
+  "tasks": {
+    "79C357A391B887D6": {
+      "type": "heracles:item",
+      "item": "indrev:biomass_generator_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "3FEA619A9B299655": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:biomass",
+        "count": 8,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "This is probably what you are looking for in terms of energy creation."
+    },
+    "description": [
+      "<h2>This is probably what you are looking for in terms of energy creation.</h2>",
+      "<hr/>",
+      "<task task=\"79C357A391B887D6\" quest=\"IR Biomass Gen MK3\"/>",
+      "<hr/>",
+      "Will burn biomass to generate energy at a significant rate, a simple crop farm can keep your energy system fed with no problems.",
+      "<hr/>",
+      "<reward reward=\"3FEA619A9B299655\" quest=\"IR Biomass Gen MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -160,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:biomass_generator_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Biomass Generator"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Cable MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Cable MK1.json
@@ -1,0 +1,86 @@
+{
+  "dependencies": [
+    "IR Servos",
+    "Nikolite Dust"
+  ],
+  "tasks": {
+    "258B02AFA8680893": {
+      "type": "heracles:item",
+      "item": "indrev:cable_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "09F245D7B37C6427": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:cable_mk1",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Cables can be used to transfer power between machines far apart from each other."
+    },
+    "description": [
+      "<h2>Cables can be used to transfer power between machines far apart from each other.</h2>",
+      "<hr/>",
+      "<task task=\"258B02AFA8680893\" quest=\"IR Cable MK1\"/>",
+      "<hr/>",
+      "<br/>",
+      "Used to distribute power. Does not require servos.",
+      "<hr/>",
+      "<reward reward=\"09F245D7B37C6427\" quest=\"IR Cable MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -352,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:cable_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Cable MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Cable MK2.json
+++ b/config/heracles/quests/industrialrevolution/IR Cable MK2.json
@@ -1,0 +1,81 @@
+{
+  "dependencies": [
+    "IR Cable MK1"
+  ],
+  "tasks": {
+    "57EABDF07EE79675": {
+      "type": "heracles:item",
+      "item": "indrev:cable_mk2",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "07707A91F2F393DF": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:cable_mk2",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"57EABDF07EE79675\" quest=\"IR Cable MK2\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"07707A91F2F393DF\" quest=\"IR Cable MK2\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -400,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:cable_mk2",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Cable MK2"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Cable MK3.json
+++ b/config/heracles/quests/industrialrevolution/IR Cable MK3.json
@@ -1,0 +1,81 @@
+{
+  "dependencies": [
+    "IR Cable MK2"
+  ],
+  "tasks": {
+    "5D2B52C752888C2A": {
+      "type": "heracles:item",
+      "item": "indrev:cable_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "1A9B7A30AAECAE28": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:cable_mk3",
+        "count": 8,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"5D2B52C752888C2A\" quest=\"IR Cable MK3\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"1A9B7A30AAECAE28\" quest=\"IR Cable MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -448,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:cable_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Cable MK3"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Cable MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Cable MK4.json
@@ -1,0 +1,75 @@
+{
+  "dependencies": [
+    "IR Cable MK3"
+  ],
+  "tasks": {
+    "indrev_cable_mk4": {
+      "type": "heracles:item",
+      "item": "indrev:cable_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "indrev_cable_mk4_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:cable_mk4",
+        "count": 8
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_cable_mk4\" quest=\"IR Cable MK4\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"indrev_cable_mk4_reward\" quest=\"IR Cable MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -496,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:cable_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "IR Cable MK4"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Charge Pad MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Charge Pad MK4.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "Circuit MK4"
+  ],
+  "tasks": {
+    "47F075B67F7DD537": {
+      "type": "heracles:item",
+      "item": "indrev:charge_pad_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "1E7965DA8EB42F5A": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:battery",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Recharge your batteries!"
+    },
+    "description": [
+      "<h2>Recharge your batteries!</h2>",
+      "<hr/>",
+      "<task task=\"47F075B67F7DD537\" quest=\"IR Charge Pad MK4\"/>",
+      "<hr/>",
+      "The charge pad allows to recharge items, batteries or equipment by placing them inside, a cable must be connected at the bottom to feed it power.",
+      "<hr/>",
+      "<reward reward=\"1E7965DA8EB42F5A\" quest=\"IR Charge Pad MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          32,
+          -240
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:charge_pad_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Charge Pad"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Coal Gen MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Coal Gen MK1.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Battery"
+  ],
+  "tasks": {
+    "7C0D0B3221DF3798": {
+      "type": "heracles:item",
+      "item": "indrev:coal_generator_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "3517F63A89FE34FE": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:coal",
+        "count": 32,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Can use, not only coal, but anything a furnace can to generate energy."
+    },
+    "description": [
+      "<h2>Can use, not only coal, but anything a furnace can to generate energy.</h2>",
+      "<hr/>",
+      "<task task=\"7C0D0B3221DF3798\" quest=\"IR Coal Gen MK1\"/>",
+      "<hr/>",
+      "The simplest method of generating power is to simply burn coal or wood, a wood farm can keep it going for long.",
+      "<hr/>",
+      "<reward reward=\"3517F63A89FE34FE\" quest=\"IR Coal Gen MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -304,
+          -48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:coal_generator_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Coal Generator"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Compressor Factory MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Compressor Factory MK4.json
@@ -1,0 +1,93 @@
+{
+  "dependencies": [
+    "IR Factory Components"
+  ],
+  "tasks": {
+    "66777FB617B6DED4": {
+      "type": "heracles:item",
+      "item": "indrev:compressor_factory_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "138AF79E3F362F35": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:steel_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    },
+    "65042EC0CA81A52C": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:silver_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Factories are improved versions of machines and they can process 5 items at once."
+    },
+    "description": [
+      "<h2>Factories are improved versions of machines and they can process 5 items at once.</h2>",
+      "<hr/>",
+      "<task task=\"66777FB617B6DED4\" quest=\"IR Compressor Factory MK4\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"138AF79E3F362F35\" quest=\"IR Compressor Factory MK4\"/>",
+      "<reward reward=\"65042EC0CA81A52C\" quest=\"IR Compressor Factory MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          240,
+          -192
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:compressor_factory_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Compressor Factory MK4"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Compressor MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Compressor MK1.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "1A45BB2D75F41120": {
+      "type": "heracles:item",
+      "item": "indrev:compressor_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "7A8B758D007E31B4": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:lead_plate",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Mainly used for compressing ingots into plates."
+    },
+    "description": [
+      "<h2>Mainly used for compressing ingots into plates.</h2>",
+      "<hr/>",
+      "<task task=\"1A45BB2D75F41120\" quest=\"IR Compressor MK1\"/>",
+      "<hr/>",
+      "Mainly used for plates but necessary for making enhancements and the fisher.",
+      "<hr/>",
+      "<reward reward=\"7A8B758D007E31B4\" quest=\"IR Compressor MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -304,
+          32
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:compressor_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Compressor MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Drain and Pump MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Drain and Pump MK1.json
@@ -1,0 +1,109 @@
+{
+  "dependencies": [
+    "Circuit MK1"
+  ],
+  "tasks": {
+    "6DA81FA2745A4BFE": {
+      "type": "heracles:item",
+      "item": "indrev:pump_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "425233ED2C940E6D": {
+      "type": "heracles:item",
+      "item": "indrev:drain_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "19808F09D6FE3E09": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:tank",
+        "count": 4,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Used to pump fluids placed in the world into fluid pipes and tanks."
+    },
+    "description": [
+      "<h2>Used to pump fluids placed in the world into fluid pipes and tanks.</h2>",
+      "<hr/>",
+      "<task task=\"6DA81FA2745A4BFE\" quest=\"IR Drain and Pump MK1\"/>",
+      "<task task=\"425233ED2C940E6D\" quest=\"IR Drain and Pump MK1\"/>",
+      "<hr/>",
+      "Usage: You must input energy from the top and take the fluid from the side it is facing.",
+      "<br/>",
+      "After receiving energy, it will drop down a pipe looking for fluids to pump.",
+      "<br/>",
+      "There is no hard limit, except for the fluid's physics.",
+      "<br/>",
+      "As long as there is fluid touching the pump's pipe, source or not, it will look for a source block to pump.",
+      "<br/>",
+      "This means it can be used to drain lava lakes from the Nether.",
+      "<br/>",
+      "The drain is like a reverse pump it will absorb fluid above itself which can then be piped into a tank, it makes for a really simple infinite water setup.",
+      "<hr/>",
+      "<reward reward=\"19808F09D6FE3E09\" quest=\"IR Drain and Pump MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -144,
+          -96
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:pump_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Pumping"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Drill Bottom.json
+++ b/config/heracles/quests/industrialrevolution/IR Drill Bottom.json
@@ -1,0 +1,128 @@
+{
+  "dependencies": [
+    "Steel Plate from IR",
+    "Circuit MK4"
+  ],
+  "tasks": {
+    "indrev_data_card_encoder": {
+      "type": "heracles:item",
+      "item": "indrev:data_card_writer_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "3A3A6FA7D635E56C": {
+      "type": "heracles:item",
+      "item": "indrev:mining_rig_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "44DA8D0214330F39": {
+      "type": "heracles:item",
+      "item": "indrev:drill_bottom",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "7E48E5130E230EB3": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:netherite_drill_head",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Damage": 0,
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "I have confidence in mining. I see exciting opportunities in it."
+    },
+    "description": [
+      "<h2>I have confidence in mining. I see exciting opportunities in it.</h2>",
+      "<hr/>",
+      "<task task=\"3A3A6FA7D635E56C\" quest=\"IR Drill Bottom\"/>",
+      "<task task=\"44DA8D0214330F39\" quest=\"IR Drill Bottom\"/>",
+      "<task task=\"indrev_data_card_encoder\" quest=\"IR Drill Bottom\"/>",
+      "<hr/>",
+      "Before making the mining rig you will need a data card encoder, in the data card encoder you can put data cards and a stack of the ore you wish the mining rig to get you.",
+      "The data cards can only get a certain amount of ores, you can also put multiple ores in the same card but this will make the card produce less overall.",
+      "There are certain modifiers to improve the cards, adding stone allows the data card produce more ores, but make sure to not go over 100% in the circle or the data card will become useless.",
+      "<br/>",
+      "The best way to use data cards is to add 1 stack of the ore you want and 15 stacks of stone for the maximum amount of ore that can be produced.",
+      "<br/>",
+      "Mining Rig Drills are required for the Mining Rig Computer to work. They have to be placed next to the Computer and require drill heads to work. Each Drill increases the mining speed.",
+      "Can hold up to 8 mining rig drills, make sure each one has a drill head.",
+      "Drills can be enchanted with unbreaking to make them last longer",
+      "<br/>",
+      "Note that the Drills can be placed connected or diagonally to the Mining Rig Computer.",
+      "<br/>",
+      "The mining rig can output to the top so place so kind of chest or storage there and make sure that it doesn't get clogged to avoid lag.",
+      "<hr/>",
+      "<reward reward=\"7E48E5130E230EB3\" quest=\"IR Drill Bottom\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          96,
+          -240
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:drill_bottom",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Mining Rig"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Electric Furnace Factory MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Electric Furnace Factory MK4.json
@@ -1,0 +1,93 @@
+{
+  "dependencies": [
+    "IR Factory Components"
+  ],
+  "tasks": {
+    "62747E8844756A8E": {
+      "type": "heracles:item",
+      "item": "indrev:electric_furnace_factory_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "059C0AB2FCC56E3F": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:steel_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    },
+    "700FE718B977F66F": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:silver_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Factories are improved versions of machines and they can process 5 items at once."
+    },
+    "description": [
+      "<h2>Factories are improved versions of machines and they can process 5 items at once.</h2>",
+      "<hr/>",
+      "<task task=\"62747E8844756A8E\" quest=\"IR Electric Furnace Factory MK4\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"059C0AB2FCC56E3F\" quest=\"IR Electric Furnace Factory MK4\"/>",
+      "<reward reward=\"700FE718B977F66F\" quest=\"IR Electric Furnace Factory MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          240,
+          -160
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:electric_furnace_factory_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Electric Furnace Factory MK4"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Empty Enhancer.json
+++ b/config/heracles/quests/industrialrevolution/IR Empty Enhancer.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Compressor MK1"
+  ],
+  "tasks": {
+    "52DD22CF4838D5B7": {
+      "type": "heracles:item",
+      "item": "indrev:empty_enhancer",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "11BF0AB4A36E9625": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:empty_enhancer",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Upgrades can boost machines stats."
+    },
+    "description": [
+      "<h2>Upgrades can boost machines stats.</h2>",
+      "<hr/>",
+      "<task task=\"52DD22CF4838D5B7\" quest=\"IR Empty Enhancer\"/>",
+      "<hr/>",
+      "The blank template with which the ehnacements will be made.",
+      "<hr/>",
+      "<reward reward=\"11BF0AB4A36E9625\" quest=\"IR Empty Enhancer\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -352,
+          32
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:empty_enhancer",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Empty Enhancer"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Energy Reader.json
+++ b/config/heracles/quests/industrialrevolution/IR Energy Reader.json
@@ -1,0 +1,83 @@
+{
+  "dependencies": [
+    "Circuit MK1"
+  ],
+  "tasks": {
+    "32475889E503F43A": {
+      "type": "heracles:item",
+      "item": "indrev:energy_reader",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "06C0F4DB51EB6ABC": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:battery",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Tells you the current stored energy in machines and, in some machines, also tells the energy consumption per tick."
+    },
+    "description": [
+      "<h2>Tells you the current stored energy in machines and, in some machines, also tells the energy consumption per tick.</h2>",
+      "<hr/>",
+      "<task task=\"32475889E503F43A\" quest=\"IR Energy Reader\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"06C0F4DB51EB6ABC\" quest=\"IR Energy Reader\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -176,
+          -96
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:energy_reader",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Energy Reader"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Enhancers.json
+++ b/config/heracles/quests/industrialrevolution/IR Enhancers.json
@@ -1,0 +1,150 @@
+{
+  "dependencies": [
+    "IR Empty Enhancer"
+  ],
+  "tasks": {
+    "6AA190C4346A526C": {
+      "type": "heracles:item",
+      "item": "indrev:speed_enhancer",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "7D6E4AA15A9FC4D7": {
+      "type": "heracles:item",
+      "item": "indrev:smoker_enhancer",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "056A302B4A42091A": {
+      "type": "heracles:item",
+      "item": "indrev:buffer_enhancer",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "2CC2B59693FA6602": {
+      "type": "heracles:item",
+      "item": "indrev:damage_enhancer",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "0D800109FAF6E8CD": {
+      "type": "heracles:item",
+      "item": "indrev:blast_furnace_enhancer",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "6B858052DF67DC3E": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:empty_enhancer",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "These upgrades will improve certain aspects of the machine like speed and energy usage."
+    },
+    "description": [
+      "<h2>These upgrades will improve certain aspects of the machine like speed and energy usage.</h2>",
+      "<hr/>",
+      "<task task=\"056A302B4A42091A\" quest=\"IR Enhancers\"/>",
+      "<task task=\"6AA190C4346A526C\" quest=\"IR Enhancers\"/>",
+      "<task task=\"0D800109FAF6E8CD\" quest=\"IR Enhancers\"/>",
+      "<task task=\"7D6E4AA15A9FC4D7\" quest=\"IR Enhancers\"/>",
+      "<task task=\"2CC2B59693FA6602\" quest=\"IR Enhancers\"/>",
+      "<hr/>",
+      "Speed: Will increase the machine's processing speed at the cost of energy.",
+      "<br/>",
+      "Buffer: Will increase the machine's internal energy capacity.",
+      "<br/>",
+      "Blasting: Will make the Electric Furnace accept Blast Furnace recipes.",
+      "<br/>",
+      "Smoker: Will make the Electric Furnace accept Smoker recipes.",
+      "<hr/>",
+      "<reward reward=\"6B858052DF67DC3E\" quest=\"IR Enhancers\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -400,
+          32
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:speed_enhancer",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Enhancers"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Factory Components.json
+++ b/config/heracles/quests/industrialrevolution/IR Factory Components.json
@@ -1,0 +1,200 @@
+{
+  "dependencies": [
+    "Steel Plate from IR"
+  ],
+  "tasks": {
+    "60ACF87793F77948": {
+      "type": "heracles:item",
+      "item": "indrev:silo",
+      "amount": 6,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "6D730271D98B0803": {
+      "type": "heracles:item",
+      "item": "indrev:controller",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "38ED6ABEB7DBD348": {
+      "type": "heracles:item",
+      "item": "indrev:frame",
+      "amount": 9,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "73B89854D6DA6CE5": {
+      "type": "heracles:item",
+      "item": "indrev:duct",
+      "amount": 3,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "01915D287A13387C": {
+      "type": "heracles:item",
+      "item": "indrev:cabinet",
+      "amount": 2,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "1C5256772EF58948": {
+      "type": "heracles:item",
+      "item": "indrev:intake",
+      "amount": 3,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "4484E6789FF66185": {
+      "type": "heracles:item",
+      "item": "indrev:warning_strobe",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "5696355503C2B666": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:redstone_block",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "5185DE4238D4AB56": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:steel_plate",
+        "count": 12
+      },
+      "type": "heracles:item"
+    },
+    "773CE85966D33F77": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:silver_plate",
+        "count": 12
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "You'll be able to visualize the block positions by right clicking a factory."
+    },
+    "description": [
+      "<h2>You'll be able to visualize the block positions by right clicking a factory.</h2>",
+      "<hr/>",
+      "<task task=\"38ED6ABEB7DBD348\" quest=\"IR Factory Components\"/>",
+      "<task task=\"60ACF87793F77948\" quest=\"IR Factory Components\"/>",
+      "<task task=\"1C5256772EF58948\" quest=\"IR Factory Components\"/>",
+      "<task task=\"73B89854D6DA6CE5\" quest=\"IR Factory Components\"/>",
+      "<task task=\"01915D287A13387C\" quest=\"IR Factory Components\"/>",
+      "<task task=\"4484E6789FF66185\" quest=\"IR Factory Components\"/>",
+      "<task task=\"6D730271D98B0803\" quest=\"IR Factory Components\"/>",
+      "<hr/>",
+      "Factories are powerful multiblock upgrades of your MK4 machines, they allow to process multiple items at once at incredible speed, make sure all the components are facing the right position or the factory won't work",
+      "<hr/>",
+      "<reward reward=\"5185DE4238D4AB56\" quest=\"IR Factory Components\"/>",
+      "<reward reward=\"773CE85966D33F77\" quest=\"IR Factory Components\"/>",
+      "<reward reward=\"5696355503C2B666\" quest=\"IR Factory Components\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          160,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "minecraft:map",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Factory Components"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Farming.json
+++ b/config/heracles/quests/industrialrevolution/IR Farming.json
@@ -1,0 +1,152 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "26E28715D93D8084": {
+      "type": "heracles:item",
+      "item": "indrev:rancher_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "7FB3E7F7BD760904": {
+      "type": "heracles:item",
+      "item": "indrev:farmer_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "69782A1D5B774112": {
+      "type": "heracles:item",
+      "item": "indrev:slaughter_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "786D0D6A0CA678EB": {
+      "type": "heracles:item",
+      "item": "indrev:chopper_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "3E53C278EB695099": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:machine_block",
+        "count": 4,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Note that it requires some items for it to function: (put them in the 2x2 square)"
+    },
+    "description": [
+      "<h2>Note that it requires some items for it to function: (put them in the 2x2 square)</h2>",
+      "<hr/>",
+      "<task task=\"786D0D6A0CA678EB\" quest=\"IR Farming\"/>",
+      "<task task=\"7FB3E7F7BD760904\" quest=\"IR Farming\"/>",
+      "<task task=\"69782A1D5B774112\" quest=\"IR Farming\"/>",
+      "<task task=\"26E28715D93D8084\" quest=\"IR Farming\"/>",
+      "<hr/>",
+      "Chopper is a machine focused in automating wood farming, and it also supports enhancement upgrades.",
+      "<br/>",
+      "> Axe: if present in the inventory, will retrieve any wood and leaves in range (leaves will not consume durability)",
+      "<br/>",
+      "> Sapling: if present in the inventory, will be planted in every block possible inside its range.",
+      "<br/>",
+      "> Bone meal: will be applied to any saplings inside its range.",
+      "<br/>",
+      "Farmer is a machine focused in crop farming, and it also supports enhancement upgrades.",
+      "<br/>",
+      "> Seeds: if present will be planted in the farmer's range. Note that it will try to match a crop and its seeds so you can use multiple crops.",
+      "<br/>",
+      "> Bone meal: if present, will fertilize any crops possible within range.",
+      "<br/>",
+      "Rancher is a machine focused in automating animal farming, and it also supports enhancement upgrades.",
+      "<br/>",
+      "> Sword: if present in the inventory, will kill animals if there are more than 7 in its range.",
+      "<br/>",
+      "> Wheat/Seed/Carrot: if present in the inventory, will be fed to the respective animals in its range.",
+      "<br/>",
+      "Bucket: if present in the inventory, will collect milk from cows.",
+      "<hr/>",
+      "<reward reward=\"3E53C278EB695099\" quest=\"IR Farming\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -304,
+          64
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "piercingpaxels:iron_paxel",
+        "count": 1,
+        "nbt": {
+          "Damage": 0
+        }
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Farming"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fisher MK2.json
+++ b/config/heracles/quests/industrialrevolution/IR Fisher MK2.json
@@ -1,0 +1,85 @@
+{
+  "dependencies": [
+    "IR Compressor MK1"
+  ],
+  "tasks": {
+    "2160975BE87B0F26": {
+      "type": "heracles:item",
+      "item": "indrev:fisher_mk2",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "6CD7DDCAC7634A6D": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:fishing_rod",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Damage": 0,
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "A machine focused in fish farming, and it also supports enhancement upgrades."
+    },
+    "description": [
+      "<h2>A machine focused in fish farming, and it also supports enhancement upgrades.</h2>",
+      "<hr/>",
+      "<task task=\"2160975BE87B0F26\" quest=\"IR Fisher MK2\"/>",
+      "<hr/>",
+      "It's only requirement is a Fishing Rod.",
+      "<hr/>",
+      "<reward reward=\"6CD7DDCAC7634A6D\" quest=\"IR Fisher MK2\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -352,
+          64
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fisher_mk2",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Basic Fisher"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fisher MK3.json
+++ b/config/heracles/quests/industrialrevolution/IR Fisher MK3.json
@@ -1,0 +1,82 @@
+{
+  "dependencies": [
+    "IR Fisher MK2"
+  ],
+  "tasks": {
+    "56CD51887FCE1BC2": {
+      "type": "heracles:item",
+      "item": "indrev:fisher_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "0E05A463DC5AB13D": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:nautilus_shell",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"56CD51887FCE1BC2\" quest=\"IR Fisher MK3\"/>",
+      "<hr/>",
+      "Unlike the basic fisher, the improved fisher will get you a decent mix of fish and treasures.",
+      "<hr/>",
+      "<reward reward=\"0E05A463DC5AB13D\" quest=\"IR Fisher MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -400,
+          64
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fisher_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Improved Fisher"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fisher MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Fisher MK4.json
@@ -1,0 +1,82 @@
+{
+  "dependencies": [
+    "IR Fisher MK3"
+  ],
+  "tasks": {
+    "365BDA0295FF4F41": {
+      "type": "heracles:item",
+      "item": "indrev:fisher_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "7B4F590CBD04DD6D": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:heart_of_the_sea",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"365BDA0295FF4F41\" quest=\"IR Fisher MK4\"/>",
+      "<hr/>",
+      "The fisher with no fish, it will only get you treasures.",
+      "<hr/>",
+      "<reward reward=\"7B4F590CBD04DD6D\" quest=\"IR Fisher MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -448,
+          64
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fisher_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Advanced Fisher"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fluid Infuser MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Fluid Infuser MK1.json
@@ -1,0 +1,86 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "297F433AB752D7CF": {
+      "type": "heracles:item",
+      "item": "indrev:fluid_infuser_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "35D35206DCBD8187": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:nikolite_dust",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Used for advanced infusing with fluids. Its main current use is for ore quadrupling."
+    },
+    "description": [
+      "<h2>Used for advanced infusing with fluids. Its main current use is for ore quadrupling.</h2>",
+      "<hr/>",
+      "<task task=\"297F433AB752D7CF\" quest=\"IR Fluid Infuser MK1\"/>",
+      "<hr/>",
+      "Can also be used to turn Sand into Clay and Concrete Powder into Concrete.",
+      "<br/>",
+      "Also used to make coolant for speed enhancements.",
+      "<hr/>",
+      "<reward reward=\"35D35206DCBD8187\" quest=\"IR Fluid Infuser MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -240,
+          96
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fluid_infuser_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Fluid Infuser MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK1.json
@@ -1,0 +1,83 @@
+{
+  "dependencies": [
+    "IR Servos"
+  ],
+  "tasks": {
+    "3D0B6ABE07C06658": {
+      "type": "heracles:item",
+      "item": "indrev:fluid_pipe_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "03D83DCD6EDF3D49": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:fluid_pipe_mk1",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Fluid pipes can be used to transfer fluids between tanks far apart."
+    },
+    "description": [
+      "<h2>Fluid pipes can be used to transfer fluids between tanks far apart.</h2>",
+      "<hr/>",
+      "<task task=\"3D0B6ABE07C06658\" quest=\"IR Fluid Pipe MK1\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"03D83DCD6EDF3D49\" quest=\"IR Fluid Pipe MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -352,
+          -112
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fluid_pipe_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Fluid Pipe MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK2.json
+++ b/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK2.json
@@ -1,0 +1,83 @@
+{
+  "dependencies": [
+    "IR Fluid Pipe MK1"
+  ],
+  "tasks": {
+    "31A68C5E6F3BE266": {
+      "type": "heracles:item",
+      "item": "indrev:fluid_pipe_mk2",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "440E72651B7C90D6": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:fluid_pipe_mk2",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Don't forget your servos"
+    },
+    "description": [
+      "<h2>Don't forget your servos</h2>",
+      "<hr/>",
+      "<task task=\"31A68C5E6F3BE266\" quest=\"IR Fluid Pipe MK2\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"440E72651B7C90D6\" quest=\"IR Fluid Pipe MK2\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -400,
+          -112
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fluid_pipe_mk2",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Fluid Pipe MK2"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK3.json
+++ b/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK3.json
@@ -1,0 +1,81 @@
+{
+  "dependencies": [
+    "IR Fluid Pipe MK2"
+  ],
+  "tasks": {
+    "338A6D704171F6EC": {
+      "type": "heracles:item",
+      "item": "indrev:fluid_pipe_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "791B97E8B46C3AB4": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:fluid_pipe_mk3",
+        "count": 8,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"338A6D704171F6EC\" quest=\"IR Fluid Pipe MK3\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"791B97E8B46C3AB4\" quest=\"IR Fluid Pipe MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -448,
+          -112
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fluid_pipe_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Fluid Pipe MK3"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Fluid Pipe MK4.json
@@ -1,0 +1,81 @@
+{
+  "dependencies": [
+    "IR Fluid Pipe MK3"
+  ],
+  "tasks": {
+    "39B41CC0BF425639": {
+      "type": "heracles:item",
+      "item": "indrev:fluid_pipe_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "0BC28E58B7DEEE0E": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:fluid_pipe_mk4",
+        "count": 8,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"39B41CC0BF425639\" quest=\"IR Fluid Pipe MK4\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"0BC28E58B7DEEE0E\" quest=\"IR Fluid Pipe MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -496,
+          -112
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:fluid_pipe_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Fluid Pipe MK4"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Heat Gen MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Heat Gen MK4.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Battery"
+  ],
+  "tasks": {
+    "5A05A31972972B83": {
+      "type": "heracles:item",
+      "item": "indrev:heat_generator_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "44EBF25DDD272F6A": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:lava_bucket",
+        "count": 3,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Will consume lava inside it to generate energy. Pairs up well with the pump."
+    },
+    "description": [
+      "<h2>Will consume lava inside it to generate energy. Pairs up well with the pump.</h2>",
+      "<hr/>",
+      "<task task=\"5A05A31972972B83\" quest=\"IR Heat Gen MK4\"/>",
+      "<hr/>",
+      "The heat generator will slowly consume lava to generate a lot of power, the longer it's running the faster it will produce energy.",
+      "<hr/>",
+      "<reward reward=\"44EBF25DDD272F6A\" quest=\"IR Heat Gen MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -208,
+          -48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:heat_generator_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Heat Generator"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Item Pipe MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Item Pipe MK1.json
@@ -1,0 +1,86 @@
+{
+  "dependencies": [
+    "IR Servos"
+  ],
+  "tasks": {
+    "5A97C9ECE9C54E89": {
+      "type": "heracles:item",
+      "item": "indrev:item_pipe_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "0FAF067F082BE5F4": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:item_pipe_mk1",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Item pipes can be used to transfer items between inventories far apart."
+    },
+    "description": [
+      "<h2>Item pipes can be used to transfer items between inventories far apart.</h2>",
+      "<hr/>",
+      "<task task=\"5A97C9ECE9C54E89\" quest=\"IR Item Pipe MK1\"/>",
+      "<hr/>",
+      "Don't forget to set the input/output of a machine.",
+      "<br/>",
+      "Also don't forget the servos. To optimize on performance, try to use the least amount of piping and servos you can if you decide to do a large operation.",
+      "<hr/>",
+      "<reward reward=\"0FAF067F082BE5F4\" quest=\"IR Item Pipe MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -352,
+          -176
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:item_pipe_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Item Pipe MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Item Pipe MK2.json
+++ b/config/heracles/quests/industrialrevolution/IR Item Pipe MK2.json
@@ -1,0 +1,83 @@
+{
+  "dependencies": [
+    "IR Item Pipe MK1"
+  ],
+  "tasks": {
+    "74534788035362A2": {
+      "type": "heracles:item",
+      "item": "indrev:item_pipe_mk2",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "0AA6FE219A0D25AA": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:item_pipe_mk2",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Don't forget your servos"
+    },
+    "description": [
+      "<h2>Don't forget your servos</h2>",
+      "<hr/>",
+      "<task task=\"74534788035362A2\" quest=\"IR Item Pipe MK2\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"0AA6FE219A0D25AA\" quest=\"IR Item Pipe MK2\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -400,
+          -176
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:item_pipe_mk2",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Item Pipe MK2"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Item Pipe MK3.json
+++ b/config/heracles/quests/industrialrevolution/IR Item Pipe MK3.json
@@ -1,0 +1,81 @@
+{
+  "dependencies": [
+    "IR Item Pipe MK2"
+  ],
+  "tasks": {
+    "57122F006261DFFC": {
+      "type": "heracles:item",
+      "item": "indrev:item_pipe_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "673C2FEFA35058A6": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:item_pipe_mk3",
+        "count": 8,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"57122F006261DFFC\" quest=\"IR Item Pipe MK3\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"673C2FEFA35058A6\" quest=\"IR Item Pipe MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -448,
+          -176
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:item_pipe_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Item Pipe MK3"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Item Pipe MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Item Pipe MK4.json
@@ -1,0 +1,81 @@
+{
+  "dependencies": [
+    "IR Item Pipe MK3"
+  ],
+  "tasks": {
+    "211F0434522552E5": {
+      "type": "heracles:item",
+      "item": "indrev:item_pipe_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "5468A1F377DE8E16": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:item_pipe_mk4",
+        "count": 8,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"211F0434522552E5\" quest=\"IR Item Pipe MK4\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"5468A1F377DE8E16\" quest=\"IR Item Pipe MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -496,
+          -176
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:item_pipe_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Item Pipe MK4"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Machine Block.json
+++ b/config/heracles/quests/industrialrevolution/IR Machine Block.json
@@ -1,0 +1,98 @@
+{
+  "dependencies": [
+    "IR Battery"
+  ],
+  "tasks": {
+    "796D98D70BE353A9": {
+      "type": "heracles:item",
+      "item": "indrev:machine_block",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "781808B2B4034E00": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:battery",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    },
+    "34040D4E9EF57B7F": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:iron_block",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"796D98D70BE353A9\" quest=\"IR Machine Block\"/>",
+      "<hr/>",
+      "The basic component for crafting any machine.",
+      "<hr/>",
+      "<reward reward=\"34040D4E9EF57B7F\" quest=\"IR Machine Block\"/>",
+      "<reward reward=\"781808B2B4034E00\" quest=\"IR Machine Block\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -256,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:machine_block",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Machine Block"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Ore Multiplication.json
+++ b/config/heracles/quests/industrialrevolution/IR Ore Multiplication.json
@@ -1,0 +1,109 @@
+{
+  "dependencies": [
+    "Circuit MK4"
+  ],
+  "tasks": {
+    "0969ABA5C3C54F24": {
+      "type": "heracles:item",
+      "item": "indrev:condenser_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "18A20622211F1C01": {
+      "type": "heracles:item",
+      "item": "indrev:smelter_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "2FCDBB4BBCA0CABD": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:lead_ore",
+        "count": 16,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Used in the process of tripling and quadrupling ore."
+    },
+    "description": [
+      "<h2>Used in the process of tripling and quadrupling ore.</h2>",
+      "<hr/>",
+      "<task task=\"0969ABA5C3C54F24\" quest=\"IR Ore Multiplication\"/>",
+      "<task task=\"18A20622211F1C01\" quest=\"IR Ore Multiplication\"/>",
+      "<hr/>",
+      "Insert your ores into an Industrial Smelter. It will smelt them into their fluid forms.",
+      "<br/>",
+      "Move your molten ore into a Condenser.",
+      "<br/>",
+      "It will solidify them into a Ore Chunk.",
+      "<br/>",
+      "Pulverize your Ore Chunk, which will then give you a dust.",
+      "<br/>",
+      "Smelt your dust.",
+      "<br/>",
+      "Done! Now you've transformed 1 ore into 3 ingots!",
+      "<hr/>",
+      "<reward reward=\"2FCDBB4BBCA0CABD\" quest=\"IR Ore Multiplication\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          64,
+          -240
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:iron_purified_ore",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Ore Multiplication"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Pulverizer Factory MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Pulverizer Factory MK4.json
@@ -1,0 +1,93 @@
+{
+  "dependencies": [
+    "IR Factory Components"
+  ],
+  "tasks": {
+    "1790DABC3E5BFAEC": {
+      "type": "heracles:item",
+      "item": "indrev:pulverizer_factory_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "298E39BB35B71199": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:steel_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    },
+    "3D4C7471B2235326": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:silver_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Factories are improved versions of machines and they can process 5 items at once."
+    },
+    "description": [
+      "<h2>Factories are improved versions of machines and they can process 5 items at once.</h2>",
+      "<hr/>",
+      "<task task=\"1790DABC3E5BFAEC\" quest=\"IR Pulverizer Factory MK4\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"298E39BB35B71199\" quest=\"IR Pulverizer Factory MK4\"/>",
+      "<reward reward=\"3D4C7471B2235326\" quest=\"IR Pulverizer Factory MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          240,
+          -128
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:pulverizer_factory_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Pulverizer Factory MK4"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Pulverizer MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Pulverizer MK1.json
@@ -1,0 +1,86 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "7BFD5C78BE44AE81": {
+      "type": "heracles:item",
+      "item": "indrev:pulverizer_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "46131EB89CEFFECD": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "minecraft:iron_ore",
+        "count": 16,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Mainly used for processing ores into two dusts."
+    },
+    "description": [
+      "<h2>Mainly used for processing ores into two dusts.</h2>",
+      "<hr/>",
+      "<task task=\"7BFD5C78BE44AE81\" quest=\"IR Pulverizer MK1\"/>",
+      "<hr/>",
+      "Make sure to check the Revolutionary Guide for more info on ore tripling and quadrupling.",
+      "<br/>",
+      "The Pulverizer will turn 1 ore into 2 dusts which can then be smelted into 2 ingots.",
+      "<hr/>",
+      "<reward reward=\"46131EB89CEFFECD\" quest=\"IR Pulverizer MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -208,
+          64
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:pulverizer_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Pulverizer MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Recycler MK2.json
+++ b/config/heracles/quests/industrialrevolution/IR Recycler MK2.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "2D28B880B3E44414": {
+      "type": "heracles:item",
+      "item": "indrev:recycler_mk2",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "2B02F5E3B81155C5": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:biomass",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Can process organic resources into biomass which can be used for energy generation."
+    },
+    "description": [
+      "<h2>Can process organic resources into biomass which can be used for energy generation.</h2>",
+      "<hr/>",
+      "<task task=\"2D28B880B3E44414\" quest=\"IR Recycler MK2\"/>",
+      "<hr/>",
+      "Seeds, crops, grass, dirt and more can be converted into biomass for future use in power generation.",
+      "<hr/>",
+      "<reward reward=\"2B02F5E3B81155C5\" quest=\"IR Recycler MK2\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -208,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:recycler_mk2",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Recycler"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Sawmill MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Sawmill MK1.json
@@ -1,0 +1,99 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "43B579461130A023": {
+      "type": "heracles:item",
+      "item": "indrev:sawmill_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "2F8A9A1509DDD699": {
+      "type": "heracles:item",
+      "item": "indrev:electric_furnace_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "57C269CE0DF67034": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:empty_enhancer",
+        "count": 2,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"2F8A9A1509DDD699\" quest=\"IR Sawmill MK1\"/>",
+      "<task task=\"43B579461130A023\" quest=\"IR Sawmill MK1\"/>",
+      "<hr/>",
+      "The electric furnace is a faster version of the regular furnace, it can also accept enhancements.",
+      "<br/>",
+      "The sawmill allows to get more planks out of each log and also gives sticks and sawdust which can be used for paper, cardboard boxes and other things. It can also accept enhancements.",
+      "<hr/>",
+      "<reward reward=\"57C269CE0DF67034\" quest=\"IR Sawmill MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -272,
+          96
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:sawmill_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Vanilla Upgrades"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Servos.json
+++ b/config/heracles/quests/industrialrevolution/IR Servos.json
@@ -1,0 +1,129 @@
+{
+  "dependencies": [
+    "Nikolite Dust"
+  ],
+  "tasks": {
+    "680A01AC3697C85A": {
+      "type": "heracles:item",
+      "item": "indrev:servo_output",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "642EC72609F0F51D": {
+      "type": "heracles:item",
+      "item": "indrev:servo_retriever",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "2782415DD5C958FC": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:servo_retriever",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    },
+    "indrev_servos_reward2": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:servo_output",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Item and fluid pipes require servos to function."
+    },
+    "description": [
+      "<h2>Item and fluid pipes require servos to function.</h2>",
+      "<hr/>",
+      "<task task=\"642EC72609F0F51D\" quest=\"IR Servos\"/>",
+      "<task task=\"680A01AC3697C85A\" quest=\"IR Servos\"/>",
+      "<hr/>",
+      "Click on the pipe connected to your container to attach a servo. Use a wrench to remove it.",
+      "<br/>",
+      "Servos have multiple modes to define priorities. Click on the servo to change it.",
+      "<br/>",
+      "Nearest first:  the servo will look for the closest container.",
+      "<br/>",
+      "Furthest first: the servo will look for the furthest container.",
+      "<br/>",
+      "Random: the servo will choose a random container.",
+      "<br/>",
+      "Round Robin: the servo will look for the container with the least amount of the transferred fluid/item.",
+      "<br/>",
+      "The Output Servo will push items/fluids to nearby containers UNLESS they are also marked as output.",
+      "<br/>",
+      "The Retriever Servo will pull items/fluids from nearby UNLESS they are also marked as retriever.",
+      "<hr/>",
+      "<reward reward=\"2782415DD5C958FC\" quest=\"IR Servos\"/>",
+      "<reward reward=\"indrev_servos_reward2\" quest=\"IR Servos\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -304,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "minecraft:map",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Servos"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Solar Gen MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Solar Gen MK1.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "2CA2353FB904C629": {
+      "type": "heracles:item",
+      "item": "indrev:solar_generator_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "7E3DC1FFEEA94B68": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:solar_generator_mk1",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Will generate energy as long as the sunlight can reach it."
+    },
+    "description": [
+      "<h2>Will generate energy as long as the sunlight can reach it.</h2>",
+      "<hr/>",
+      "<task task=\"2CA2353FB904C629\" quest=\"IR Solar Gen MK1\"/>",
+      "<hr/>",
+      "It's not the best or fastest but it's free energy after all.",
+      "<hr/>",
+      "<reward reward=\"7E3DC1FFEEA94B68\" quest=\"IR Solar Gen MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -304,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:solar_generator_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Solar Generator MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Solar Gen MK3.json
+++ b/config/heracles/quests/industrialrevolution/IR Solar Gen MK3.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Solar Gen MK1"
+  ],
+  "tasks": {
+    "69D934CCE991022B": {
+      "type": "heracles:item",
+      "item": "indrev:solar_generator_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "14A566B17F4B8DE1": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:solar_generator_mk3",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Will generate energy as long as the sunlight can reach it."
+    },
+    "description": [
+      "<h2>Will generate energy as long as the sunlight can reach it.</h2>",
+      "<hr/>",
+      "<task task=\"69D934CCE991022B\" quest=\"IR Solar Gen MK3\"/>",
+      "<hr/>",
+      "An improved version of the regular solar generator.",
+      "<hr/>",
+      "<reward reward=\"14A566B17F4B8DE1\" quest=\"IR Solar Gen MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -352,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:solar_generator_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Solar Generator MK3"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Solid Infuser Factory MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Solid Infuser Factory MK4.json
@@ -1,0 +1,93 @@
+{
+  "dependencies": [
+    "IR Factory Components"
+  ],
+  "tasks": {
+    "37B41479BCC582F1": {
+      "type": "heracles:item",
+      "item": "indrev:solid_infuser_factory_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "533A073C50011CC1": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:silver_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    },
+    "0C24F97292B6B471": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:steel_plate",
+        "count": 3
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Factories are improved versions of machines and they can process 5 items at once."
+    },
+    "description": [
+      "<h2>Factories are improved versions of machines and they can process 5 items at once.</h2>",
+      "<hr/>",
+      "<task task=\"37B41479BCC582F1\" quest=\"IR Solid Infuser Factory MK4\"/>",
+      "<hr/>",
+      "<hr/>",
+      "<reward reward=\"0C24F97292B6B471\" quest=\"IR Solid Infuser Factory MK4\"/>",
+      "<reward reward=\"533A073C50011CC1\" quest=\"IR Solid Infuser Factory MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          240,
+          -96
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:solid_infuser_factory_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Solid Infuser Factory MK4"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Solid Infuser MK1.json
+++ b/config/heracles/quests/industrialrevolution/IR Solid Infuser MK1.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Machine Block"
+  ],
+  "tasks": {
+    "149E01643E01157E": {
+      "type": "heracles:item",
+      "item": "indrev:solid_infuser_mk1",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "410ED412233723AF": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:nikolite_dust",
+        "count": 8,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Has the capability of mixing two ingredients into a different one."
+    },
+    "description": [
+      "<h2>Has the capability of mixing two ingredients into a different one.</h2>",
+      "<hr/>",
+      "<task task=\"149E01643E01157E\" quest=\"IR Solid Infuser MK1\"/>",
+      "<hr/>",
+      "Mainly used to enrich nikolite for better tiers of machines, can also be used to duplicate flowers, mushrooms and some saplings.",
+      "<hr/>",
+      "<reward reward=\"410ED412233723AF\" quest=\"IR Solid Infuser MK1\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -208,
+          32
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:solid_infuser_mk1",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Solid Infuser MK1"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Tier Upgrade MK2.json
+++ b/config/heracles/quests/industrialrevolution/IR Tier Upgrade MK2.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "Circuit MK2"
+  ],
+  "tasks": {
+    "4F4D8685014D737B": {
+      "type": "heracles:item",
+      "item": "indrev:tier_upgrade_mk2",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "587EA64BEAEB47E2": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:circuit_mk2",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Upgrades MK1 machines to MK2."
+    },
+    "description": [
+      "<h2>Upgrades MK1 machines to MK2.</h2>",
+      "<hr/>",
+      "<task task=\"4F4D8685014D737B\" quest=\"IR Tier Upgrade MK2\"/>",
+      "<hr/>",
+      "These upgrades will improve the machine's input and output capability as well as other aspects. Right clicking on a machine below the upgrade's tier will upgrade it.",
+      "<hr/>",
+      "<reward reward=\"587EA64BEAEB47E2\" quest=\"IR Tier Upgrade MK2\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -96,
+          -192
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:tier_upgrade_mk2",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "MK2 Machine Upgrade"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Tier Upgrade MK3.json
+++ b/config/heracles/quests/industrialrevolution/IR Tier Upgrade MK3.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "Circuit MK3"
+  ],
+  "tasks": {
+    "67E4C8E1A578868E": {
+      "type": "heracles:item",
+      "item": "indrev:tier_upgrade_mk3",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "3272E3642C6BAEB3": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:circuit_mk3",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Upgrades MK2 machines to MK3."
+    },
+    "description": [
+      "<h2>Upgrades MK2 machines to MK3.</h2>",
+      "<hr/>",
+      "<task task=\"67E4C8E1A578868E\" quest=\"IR Tier Upgrade MK3\"/>",
+      "<hr/>",
+      "These upgrades will improve the machine's input and output capability as well as other aspects. Right clicking on a machine below the upgrade's tier will upgrade it.",
+      "<hr/>",
+      "<reward reward=\"3272E3642C6BAEB3\" quest=\"IR Tier Upgrade MK3\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -32,
+          -192
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:tier_upgrade_mk3",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "MK3 Machine Upgrade"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR Tier Upgrade MK4.json
+++ b/config/heracles/quests/industrialrevolution/IR Tier Upgrade MK4.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "Circuit MK4"
+  ],
+  "tasks": {
+    "0D4A3AF2AE73BE76": {
+      "type": "heracles:item",
+      "item": "indrev:tier_upgrade_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "07F13B3B745111E0": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:circuit_mk4",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Upgrades MK3 machines to MK4."
+    },
+    "description": [
+      "<h2>Upgrades MK3 machines to MK4.</h2>",
+      "<hr/>",
+      "<task task=\"0D4A3AF2AE73BE76\" quest=\"IR Tier Upgrade MK4\"/>",
+      "<hr/>",
+      "These upgrades will improve the machine's input and output capability as well as other aspects. Right clicking on a machine below the upgrade's tier will upgrade it.",
+      "<hr/>",
+      "<reward reward=\"07F13B3B745111E0\" quest=\"IR Tier Upgrade MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          0,
+          -240
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:tier_upgrade_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "MK4 Machine Upgrade"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/IR needs only the best diamonds.json
+++ b/config/heracles/quests/industrialrevolution/IR needs only the best diamonds.json
@@ -1,0 +1,84 @@
+{
+  "dependencies": [
+    "IR Pulverizer MK1"
+  ],
+  "tasks": {
+    "2A7E8398F675F060": {
+      "type": "heracles:item",
+      "item": "modern_industrialization:diamond_dust",
+      "amount": 4,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "74FA63591DEBE176": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:diamond_dust",
+        "count": 2,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "With a desire for the finest. Indrev tech needs only the best diamonds."
+    },
+    "description": [
+      "<h2>With a desire for the finest. Indrev tech needs only the best diamonds.</h2>",
+      "<hr/>",
+      "<task task=\"2A7E8398F675F060\" quest=\"IR needs only the best diamonds\"/>",
+      "<hr/>",
+      "Diamond dust will be necessary for the creation of better forms of nikolite.",
+      "<hr/>",
+      "<reward reward=\"74FA63591DEBE176\" quest=\"IR needs only the best diamonds\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -96,
+          64
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "modern_industrialization:diamond_dust",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Diamond Dust"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Modular Boots.json
+++ b/config/heracles/quests/industrialrevolution/Modular Boots.json
@@ -1,0 +1,78 @@
+{
+  "dependencies": [
+    "Modular Core Activated"
+  ],
+  "tasks": {
+    "indrev_modular_boots": {
+      "type": "heracles:item",
+      "item": "indrev:modular_armor_boots",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "indrev_modular_boots_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:module_color_black",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_modular_boots\" quest=\"Modular Boots\"/>",
+      "<hr/>",
+      "The Modular boots can be upgraded with certain unique modules:",
+      "-Jump boost module",
+      "-Feather falling module",
+      "<hr/>",
+      "<reward reward=\"indrev_modular_boots_reward\" quest=\"Modular Boots\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          156,
+          48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:modular_armor_boots",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Modular Boots"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Modular Chestplate.json
+++ b/config/heracles/quests/industrialrevolution/Modular Chestplate.json
@@ -1,0 +1,78 @@
+{
+  "dependencies": [
+    "Modular Core Activated"
+  ],
+  "tasks": {
+    "indrev_modular_chestplate": {
+      "type": "heracles:item",
+      "item": "indrev:modular_armor_chest",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "indrev_modular_chestplate_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:module_color_yellow",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_modular_chestplate\" quest=\"Modular Chestplate\"/>",
+      "<hr/>",
+      "The Modular chestplate provides elytra flight, it can also be upgraded with certain unique modules:",
+      "-Charger module",
+      "-Fire resistance module",
+      "<hr/>",
+      "<reward reward=\"indrev_modular_chestplate_reward\" quest=\"Modular Chestplate\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          96,
+          48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:modular_armor_chest",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Modular Chestplate"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Modular Core Activated.json
+++ b/config/heracles/quests/industrialrevolution/Modular Core Activated.json
@@ -1,0 +1,82 @@
+{
+  "dependencies": [
+    "Charging the Core"
+  ],
+  "tasks": {
+    "35D41B3A51A85FF6": {
+      "type": "heracles:item",
+      "item": "indrev:modular_core_activated",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "5A5099B092E1219D": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:module_color_blue",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"35D41B3A51A85FF6\" quest=\"Modular Core Activated\"/>",
+      "<hr/>",
+      "The installed modules on your gear can be configured by pressing K.",
+      "<hr/>",
+      "<reward reward=\"5A5099B092E1219D\" quest=\"Modular Core Activated\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          96,
+          0
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:modular_core_activated",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Core of Modularity"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Modular Helmet.json
+++ b/config/heracles/quests/industrialrevolution/Modular Helmet.json
@@ -1,0 +1,80 @@
+{
+  "dependencies": [
+    "Modular Core Activated"
+  ],
+  "tasks": {
+    "indrev_modular_helmet": {
+      "type": "heracles:item",
+      "item": "indrev:modular_armor_helmet",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "indrev_modular_helmet_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:module_color_red",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_modular_helmet\" quest=\"Modular Helmet\"/>",
+      "<hr/>",
+      "The Modular helmet can be upgraded with certain unique modules:",
+      "-Night vision module",
+      "-Breathing module",
+      "-Auto feeder module",
+      "-Solar panel module",
+      "<hr/>",
+      "<reward reward=\"indrev_modular_helmet_reward\" quest=\"Modular Helmet\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          66,
+          48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:modular_armor_helmet",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Modular Helmet"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Modular Leggings.json
+++ b/config/heracles/quests/industrialrevolution/Modular Leggings.json
@@ -1,0 +1,77 @@
+{
+  "dependencies": [
+    "Modular Core Activated"
+  ],
+  "tasks": {
+    "indrev_modular_leggings": {
+      "type": "heracles:item",
+      "item": "indrev:modular_armor_legs",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "indrev_modular_leggings_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:module_color_green",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_modular_leggings\" quest=\"Modular Leggings\"/>",
+      "<hr/>",
+      "The Modular leggings can be upgraded with an unique module:",
+      "-Speed module",
+      "<hr/>",
+      "<reward reward=\"indrev_modular_leggings_reward\" quest=\"Modular Leggings\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          126,
+          48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:modular_armor_legs",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Modular Leggings"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Modular Mining Drill.json
+++ b/config/heracles/quests/industrialrevolution/Modular Mining Drill.json
@@ -1,0 +1,76 @@
+{
+  "dependencies": [
+    "Modular Core Activated"
+  ],
+  "tasks": {
+    "indrev_modular_mining_drill": {
+      "type": "heracles:item",
+      "item": "indrev:mining_drill_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "modular_mining_drill_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:module_efficiency",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_modular_mining_drill\" quest=\"Modular Mining Drill\"/>",
+      "<hr/>",
+      "The Modular mining drill is a powerful tool, it can be upgraded for extra speed and range and with the fortune and silk touch modules you can switch between them on the go.",
+      "<hr/>",
+      "<reward reward=\"modular_mining_drill_reward\" quest=\"Modular Mining Drill\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          186,
+          48
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:mining_drill_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Modular Mining Drill"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Modular Workbench MK4.json
+++ b/config/heracles/quests/industrialrevolution/Modular Workbench MK4.json
@@ -1,0 +1,90 @@
+{
+  "dependencies": [
+    "Steel Plate from IR"
+  ],
+  "tasks": {
+    "140BC8875C9E1DB1": {
+      "type": "heracles:item",
+      "item": "indrev:modular_workbench_mk4",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "1C33ED6AFA03FA1F": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:circuit_mk4",
+        "count": 1,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Used to craft and install modules."
+    },
+    "description": [
+      "<h2>Used to install modules onto Modular Armor parts.</h2>",
+      "<hr/>",
+      "<task task=\"140BC8875C9E1DB1\" quest=\"Modular Workbench MK4\"/>",
+      "<hr/>",
+      "The modular workbench allows to craft and install modules.",
+      "<br/>",
+      "Notice that installing modules cost time and some energy!",
+      "<br/>",
+      "The Modular Armor is, on its own, not much, but when you install modules, it can become very powerful!",
+      "<br/>",
+      "Modules can also be used on the modular mining drill and the gamer axe.",
+      "<hr/>",
+      "<reward reward=\"1C33ED6AFA03FA1F\" quest=\"Modular Workbench MK4\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          96,
+          -96
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:modular_workbench_mk4",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Modular Workbench"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Nikolite Dust.json
+++ b/config/heracles/quests/industrialrevolution/Nikolite Dust.json
@@ -1,0 +1,78 @@
+{
+  "dependencies": [
+    "Welcome to the Revolution"
+  ],
+  "tasks": {
+    "Nikolite Dust.b": {
+      "type": "heracles:item",
+      "item": "indrev:nikolite_dust",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "361AEFAEDC96E694": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:nikolite_dust",
+        "count": 8
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "This material helped spark a myriad of devices. Forever changing the universe."
+    },
+    "description": [
+      "<h2>This material helped spark a myriad of devices. Forever changing the universe.</h2>",
+      "<hr/>",
+      "<task task=\"Nikolite Dust.b\" quest=\"Nikolite Dust\"/>",
+      "<hr/>",
+      "Main component used in machines, from basic to advanced.",
+      "<hr/>",
+      "<reward reward=\"361AEFAEDC96E694\" quest=\"Nikolite Dust\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -256,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:nikolite_dust",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Nikolite Dust"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Nikolite Ingot.json
+++ b/config/heracles/quests/industrialrevolution/Nikolite Ingot.json
@@ -1,0 +1,82 @@
+{
+  "dependencies": [
+    "IR Solid Infuser MK1"
+  ],
+  "tasks": {
+    "7A11B4D7826DE872": {
+      "type": "heracles:item",
+      "item": "indrev:nikolite_ingot",
+      "amount": 4,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "16F4C873564D448B": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:nikolite_ingot",
+        "count": 4,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"7A11B4D7826DE872\" quest=\"Nikolite Ingot\"/>",
+      "<hr/>",
+      "Nikolite ingots are a slightly more refined version of nikolite, with it MK2 upgrades are now available.",
+      "<hr/>",
+      "<reward reward=\"16F4C873564D448B\" quest=\"Nikolite Ingot\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -96,
+          32
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:nikolite_ingot",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Nikolite Ingot"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Poor Mans Compressor.json
+++ b/config/heracles/quests/industrialrevolution/Poor Mans Compressor.json
@@ -1,0 +1,119 @@
+{
+  "dependencies": [
+    "Nikolite Dust"
+  ],
+  "tasks": {
+    "38FF00648317CA47": {
+      "type": "heracles:item",
+      "item": "modern_industrialization:tin_plate",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "3F644DD10ADA8B85": {
+      "type": "heracles:item",
+      "item": "modern_industrialization:copper_plate",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    },
+    "550F31D9A31FE1AC": {
+      "type": "heracles:item",
+      "item": "modern_industrialization:iron_plate",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "278A2E90AFCDB9A0": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:steel_hammer",
+        "count": 1,
+        "nbt": {
+          "Type": "COMMON",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/common",
+          "Damage": 0,
+          "Name": "Industrial Revolution Common Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Craft a Forge Hammer from MI and make your first plates."
+    },
+    "description": [
+      "<h2>Craft a Forge Hammer from MI and make your first plates.</h2>",
+      "<hr/>",
+      "<task task=\"38FF00648317CA47\" quest=\"Poor Mans Compressor\"/>",
+      "<task task=\"3F644DD10ADA8B85\" quest=\"Poor Mans Compressor\"/>",
+      "<task task=\"550F31D9A31FE1AC\" quest=\"Poor Mans Compressor\"/>",
+      "<hr/>",
+      "TIP: Use hammers while crafting in the Forge Hammer.",
+      "<br/>",
+      "These hammers will save you lots of resources.",
+      "<br/>",
+      "NOTE: Indrev Hammer is disabled.",
+      "<hr/>",
+      "<reward reward=\"278A2E90AFCDB9A0\" quest=\"Poor Mans Compressor\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -256,
+          -96
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "minecraft:map",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Poor Man's Compressor"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Steel Plate from IR.json
+++ b/config/heracles/quests/industrialrevolution/Steel Plate from IR.json
@@ -1,0 +1,82 @@
+{
+  "dependencies": [
+    "Circuit MK4"
+  ],
+  "tasks": {
+    "76A9AC313BDD324B": {
+      "type": "heracles:item",
+      "item": "modern_industrialization:steel_plate",
+      "amount": 4,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "37847037A012D05C": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "modern_industrialization:steel_plate",
+        "count": 4,
+        "nbt": {
+          "Type": "RARE",
+          "Color": 8090608,
+          "Loot": "aof:loot_bags/ind_rev/rare",
+          "Name": "Industrial Revolution Rare Lootbag"
+        }
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"76A9AC313BDD324B\" quest=\"Steel Plate from IR\"/>",
+      "<hr/>",
+      "Steel plates are necessary for the best machines.",
+      "<hr/>",
+      "<reward reward=\"37847037A012D05C\" quest=\"Steel Plate from IR\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          96,
+          -144
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "modern_industrialization:steel_plate",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Steel Plates"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Welcome to the Revolution.json
+++ b/config/heracles/quests/industrialrevolution/Welcome to the Revolution.json
@@ -1,0 +1,77 @@
+{
+  "dependencies": [],
+  "tasks": {
+    "5AA23A717BC9D641": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "indrev:guide_book",
+          "count": 1
+        },
+        "type": "heracles:item"
+      },
+      "type": "heracles:check"
+    }
+  },
+  "rewards": {
+    "419AC8433FA360AA": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:guide_book",
+        "count": 1
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "translate": "Choose the best. Choose INDREV!"
+    },
+    "description": [
+      "<h2>Choose the best. Choose INDREV!</h2>",
+      "<hr/>",
+      "<task task=\"5AA23A717BC9D641\" quest=\"Welcome to the Revolution\"/>",
+      "<hr/>",
+      "Scientists have done a good job at making machines smart enough not to explode and to benefit from temperature. Every machine has an optimal temperature which will never be exceeded.",
+      "<br/>",
+      "In order for the machine to stay on its optimal temperature, it needs to cool down often.",
+      "<br/>",
+      "While it's cooling down, it will not have the efficiency boost.",
+      "<hr/>",
+      "<reward reward=\"419AC8433FA360AA\" quest=\"Welcome to the Revolution\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          -256,
+          -240
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:guide_book",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Welcome to the Revolution!"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}

--- a/config/heracles/quests/industrialrevolution/Wither Proof Obsidian.json
+++ b/config/heracles/quests/industrialrevolution/Wither Proof Obsidian.json
@@ -1,0 +1,76 @@
+{
+  "dependencies": [
+    "IR Ore Multiplication"
+  ],
+  "tasks": {
+    "indrev_wither_proof_obsidian": {
+      "type": "heracles:item",
+      "item": "indrev:wither_proof_obsidian",
+      "amount": 1,
+      "collection": "AUTOMATIC",
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      }
+    }
+  },
+  "rewards": {
+    "wither_obsidian_reward": {
+      "title": "",
+      "icon": {
+        "item": {
+          "id": "minecraft:air",
+          "count": 0
+        },
+        "type": "heracles:item"
+      },
+      "item": {
+        "id": "indrev:wither_proof_obsidian",
+        "count": 16
+      },
+      "type": "heracles:item"
+    }
+  },
+  "display": {
+    "subtitle": {
+      "text": ""
+    },
+    "description": [
+      "<task task=\"indrev_wither_proof_obsidian\" quest=\"Wither Proof Obsidian\"/>",
+      "<hr/>",
+      "Now that you can melt iron into a liquid you can reinforce obsidian to be wither proof, this will reduce the risk of any accidents.",
+      "<hr/>",
+      "<reward reward=\"wither_obsidian_reward\" quest=\"Wither Proof Obsidian\"/>"
+    ],
+    "groups": {
+      "Industrial Revolution": {
+        "position": [
+          64,
+          -275
+        ]
+      }
+    },
+    "icon": {
+      "item": {
+        "id": "indrev:wither_proof_obsidian",
+        "count": 1
+      },
+      "type": "heracles:item"
+    },
+    "icon_background": "heracles:textures/gui/quest_backgrounds/default.png",
+    "title": {
+      "translate": "Wither Proof Obsidian"
+    }
+  },
+  "settings": {
+    "unlockNotification": false,
+    "showDependencyArrow": true,
+    "repeatable": false,
+    "individual_progress": false,
+    "hidden": "LOCKED"
+  }
+}


### PR DESCRIPTION
Updated broken quest icons
Fixed some grammatical errors
Updated or added multiple descriptions
Expanded the mining rig quest with the data card encoder and more info about optimal use Expanded the laser emmiters descriptions with extra info and warnings to avoid explosions Added quests for all modular gear with info about unique modules Added quest for wither proof obsidian
Updated all rewards to get rid of old lootbags