### PR TITLE
Baconification

### DIFF
--- a/kubejs/server_scripts/replace_inputs.js
+++ b/kubejs/server_scripts/replace_inputs.js
@@ -9,8 +9,4 @@ ServerEvents.recipes(event => {
     // Chests
     event.replaceInput({}, '#c:wooden_chests', '#c:wooden_chests')
     event.replaceInput({}, 'minecraft:chest', '#c:wooden_chests')
-
-    // Bacon
-    event.replaceInput({}, 'croptopia:bacon', '#c:raw_bacon')
-    event.replaceInput({}, 'croptopia:cooked_bacon', '#c:cooked_bacon')
 });

--- a/kubejs/server_scripts/replace_inputs.js
+++ b/kubejs/server_scripts/replace_inputs.js
@@ -9,4 +9,8 @@ ServerEvents.recipes(event => {
     // Chests
     event.replaceInput({}, '#c:wooden_chests', '#c:wooden_chests')
     event.replaceInput({}, 'minecraft:chest', '#c:wooden_chests')
+
+    // Bacon
+    event.replaceInput({}, 'croptopia:bacon', '#c:raw_bacon')
+    event.replaceInput({}, 'croptopia:cooked_bacon', '#c:cooked_bacon')
 });

--- a/kubejs/server_scripts/tags/farming.js
+++ b/kubejs/server_scripts/tags/farming.js
@@ -24,13 +24,15 @@ ServerEvents.tags('item', event => {
   event.add('c:doughs', 'create:dough')
   event.add('c:doughs', 'bakery:dough')
 
-   // Garlic
-   event.add('c:garlic', 'bewitchment:garlic')
-   event.add('c:crops/garlic', 'bewitchment:garlic')
+  // Garlic
+  event.add('c:garlic', 'bewitchment:garlic')
+  event.add('c:crops/garlic', 'bewitchment:garlic')
 
   // Bacon
   event.add('c:raw_bacon', 'croptopia:bacon')
+  event.add('c:raw_bacon', 'farmersdelight:bacon')
   event.add('c:cooked_bacon', 'croptopia:cooked_bacon')
+  event.add('c:cooked_bacon', 'farmersdelight:cooked_bacon')
 
   // Duck eggs
   event.add('c:eggs', 'duckling:duck_egg')
@@ -38,13 +40,13 @@ ServerEvents.tags('item', event => {
   // event.add('naturalist:snake_temp_items', 'duckling:duck_egg')
   event.add('farmersdelight:cabbage_roll_ingredients', 'duckling:duck_egg')
 
-   // Strawberries
-   event.add('c:strawberries', 'bakery:strawberry')
+  // Strawberries
+  event.add('c:strawberries', 'bakery:strawberry')
 
-   // Cheese
-   event.add('c:cheese', 'croptopia:cheese')
-   event.add('c:cheeses', 'meadow:piece_of_cheese')
+  // Cheese
+  event.add('c:cheese', 'croptopia:cheese')
+  event.add('c:cheeses', 'meadow:piece_of_cheese')
 
-   // Seeds
-   event.add('c:seeds', 'supplementaries:flax_seeds')
+  // Seeds
+  event.add('c:seeds', 'supplementaries:flax_seeds')
 });


### PR DESCRIPTION
Added tags `c:raw_bacon` and `c:cooked_bacon` to `farmersdelight:bacon` and `farmersdelight:cooked_bacon` respectively, as well as replacing inputs requiring `croptopia:bacon` or `croptopia:cooked_bacon` to use tags instead.

This should enable the following recipes that are currently uncraftable without Croptopia bacon:
`croptopia:potato_soup`
`croptopia:the_big_breakfast`
`croptopia:blt`