### PR TITLE
Update adventurez.json5

### DIFF
--- a/config/adventurez.json5
+++ b/config/adventurez.json5
@@ -15,7 +15,7 @@
 	"ender_whale_spawn_weight": 5,
 	"iguana_spawn_weight": 10,
 	// Chance for spawning when geode generates; 1/Value
-	"amethyst_golem_spawn_chance": 5,
+	"amethyst_golem_spawn_chance": 20,
 	"desert_rhino_spawn_weight": 1,
 	// Chance for spawning when desert well generates; 1/Value
 	"desert_rhino_well_spawn_chance": 1,


### PR DESCRIPTION
This PR decreases spawn chance for Amethyst Golems from 20% to 5%, since the increased quantity and frequency of geodes in AOF7 tends to result in them spawning much more often than is probably intended.