### PR TITLE
Update ore tags & Mining Rig config

### DIFF
--- a/config/farmingforblockheads/MarketRegistry.json
+++ b/config/farmingforblockheads/MarketRegistry.json
@@ -12,10 +12,15 @@
          "icon":{
             "item":"regions_unexplored:pine_shrub"
          }
+      },
+      "ribbits":{
+         "name":"Ribbits",
+         "icon":{
+            "item":"ribbits:toadstool"
+         }
       }
    },
-
-   "customEntries":[      
+   "customEntries":[
       {
          "output":{
             "item":"regions_unexplored:acacia_shrub"
@@ -331,12 +336,6 @@
          },
          "category":"shrubs"
       },
-
-
-
-
-
-      
       {
          "output":{
             "item":"bakery:oat_seeds"
@@ -544,10 +543,6 @@
          },
          "category":"farmingforblockheads:seeds"
       },
-
-
-      
-      
       {
          "output":{
             "item":"beachparty:palm_sapling"
@@ -1025,11 +1020,6 @@
          },
          "category":"farmingforblockheads:saplings"
       },
-
-
-
-
-      
       {
          "output":{
             "item":"minecraft:brown_mushroom"
@@ -1101,6 +1091,78 @@
             "item":"minecraft:emerald"
          },
          "category":"fungi"
+      },
+      {
+         "output":{
+            "item":"ribbits:brown_toadstool"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
+      },
+      {
+         "output":{
+            "item":"ribbits:giant_lilypad"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
+      },
+      {
+         "output":{
+            "item":"ribbits:red_toadstool"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
+      },
+      {
+         "output":{
+            "item":"ribbits:swamp_daisy"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
+      },
+      {
+         "output":{
+            "item":"ribbits:toadstool"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
+      },
+      {
+         "output":{
+            "item":"ribbits:toadstool_stem"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
+      },
+      {
+         "output":{
+            "item":"ribbits:umbrella_leaf"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
+      },
+      {
+         "output":{
+            "item":"ribbits:swamp_lantern"
+         },
+         "payment":{
+            "item":"minecraft:amethyst_shard"
+         },
+         "category":"ribbits"
       }
    ]
 }

--- a/config/indrev/mining_rig_config.json
+++ b/config/indrev/mining_rig_config.json
@@ -12,7 +12,7 @@
     "c:cinnabar_ores": 4,
     "c:diamond_ores": 4,
     "c:galena_ores": 4,
-    "jewelry:gem_veins": 4,
+    "c:jewelry_gem_vein": 4,
     "c:gold_ores": 4,
     "c:iron_ores": 4,
     "c:lapis_ores": 4,
@@ -38,7 +38,7 @@
     "c:tungsten_ores": 10,
     "c:uranium_ores": 10,
     "c:uraninite_ores": 10,
-    "mythicmetals:ores": 10,
+    "c:mythicmetals_ores": 10,
     "c:mythicupgrades_ores": 10
   }
 }

--- a/kubejs/server_scripts/tags/materials.js
+++ b/kubejs/server_scripts/tags/materials.js
@@ -150,7 +150,77 @@ ServerEvents.tags('item', event => {
 
     mythicmetals_nuggets.forEach((item) => {
         event.add("c:" + item + "_nuggets", "mythicmetals:" + item + "_nugget")
+    });
+    
+    // JewelryRPG
+    event.add("c:jewelry_gem_vein", "jewelry:gem_vein")
+    
+    // Mythic Metals ores
+    const mythicmetals_ores = [
+        "adamantite_ore",
+        "aquarium_ore",
+        "banglum_ore",
+        "blackstone_stormyx_ore",
+        "calcite_kyber_ore",
+        "calcite_starrite_ore",
+        "carmot_ore",
+        "deepslate_adamantite_ore",
+        "deepslate_carmot_ore",
+        "deepslate_morkite_ore",
+        "deepslate_mythril_ore",
+        "deepslate_orichalcum_ore",
+        "deepslate_prometheum_ore",
+        "deepslate_runite_ore",
+        "deepslate_unobtainium_ore",
+        "end_stone_starrite_ore",
+        "kyber_ore",
+        "manganese_ore",
+        "midas_gold_ore",
+        "morkite_ore",
+        "mythril_ore",
+        "nether_banglum_ore",
+        "orichalcum_ore",
+        "osmium_ore",
+        "palladium_ore",
+        "platinum_ore",
+        "prometheum_ore",
+        "quadrillum_ore",
+        "runite_ore",
+        "silver_ore",
+        "smooth_basalt_orichalcum_ore",
+        "starrite_ore",
+        "stormyx_ore",
+        "tin_ore",
+        "tuff_orichalcum_ore",
+        "unobtainium_ore"
+    ];
+
+    mythicmetals_ores.forEach((item) => {
+        event.add("c:mythicmetals_ores", "mythicmetals:" + item)
+    });
+
+    // Mythic Upgrades ores
+    const mythicupgrades_ores = [
+        "aquamarine_ore",
+        "deepslate_aquamarine_ore",
+        "citrine_ore",
+        "deepslate_citrine_ore",
+        "peridot_ore",
+        "deepslate_peridot_ore",
+        "zircon_ore",
+        "deepslate_zircon_ore",
+        "ruby_ore",
+        "sapphire_ore",
+        "topaz_ore",
+        "ametrine_ore",
+        "jade_ore",
+        "necoium_ore"
+    ];
+
+    mythicupgrades_ores.forEach((item) => {
+        event.add("c:mythicupgrades_ores", "mythicupgrades:" + item)
     })
+    
 })
 
 ServerEvents.tags('block', event => {
@@ -191,28 +261,6 @@ ServerEvents.tags('block', event => {
 
     geodeplus_ae2.forEach((item) => {
         event.add("ae2:growth_acceleratable", "geode_plus:" + item)
-    });
-
-    // Mythic Upgrades ores
-	const mythicupgrades_ores = [
-		"aquamarine_ore",
-		"deepslate_aquamarine_ore",
-		"citrine_ore",
-		"deepslate_citrine_ore",
-		"peridot_ore",
-		"deepslate_peridot_ore",
-		"zircon_ore",
-		"deepslate_zircon_ore",
-		"ruby_ore",
-		"sapphire_ore",
-		"topaz_ore",
-		"ametrine_ore",
-		"jade_ore",
-		"necoium_ore"
-	];
-
-    mythicupgrades_ores.forEach((item) => {
-        event.add("c:mythicupgrades_ores", "mythicupgrades:" + item)
     });
 
 });


### PR DESCRIPTION
This PR fixes a minor derp in my [previous PR](https://github.com/TeamAOF/All-of-Fabric-7/pull/261) by adding the new tags as _item tags_ rather than block tags. A minor adjustment was made to the mining rig config for consistency.

Confirmed working in latest version (2.3.0):
![image](https://github.com/TeamAOF/All-of-Fabric-7/assets/50662839/7e45750c-21e0-4863-b5c3-4cc4bb6cf9a2)
![image](https://github.com/TeamAOF/All-of-Fabric-7/assets/50662839/dbbfd410-8a77-4315-ba79-0aa85ce2f0ce)
![image](https://github.com/TeamAOF/All-of-Fabric-7/assets/50662839/52f5b2b6-c8ef-4d85-8e98-be48f33373eb)

